### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Sentry.init({
 
 // then run any scenario that should call Sentry.catchException(...)
 
-expect(testKit.reports()).toHaveLength(1)
-const report = testKit.reports()[0]
+expect(testkit.reports()).toHaveLength(1)
+const report = testkit.reports()[0]
 expect(report).toHaveProperty(...)
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ npm install sentry-testkit --save-dev
 const sentryTestkit = require('sentry-testkit')
 
 const {testkit, sentryTransport} = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 // initialize your Sentry instance with sentryTransport
 Sentry.init({
-    dsn: 'some_dummy_dsn',
+    dsn: DUMMY_DSN,
     transport: sentryTransport,
     //... other configurations
 })


### PR DESCRIPTION
The README suggests using a random string as a DSN, this will fail. Using an empty string will cause Sentry to just not load (or so it seems).

This PR updates the docs to match the test

https://github.com/wix/sentry-testkit/blob/b876bb80b832af8b1df6ff0cea42c028721b96cd/test/index.test.js#L9-L17
Also, the README uses `testKit` instead of `testkit`

