### PR TITLE
Add `close` method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,10 +47,17 @@ module.exports = () => {
         })
       }
 
+      const close = function() {
+        return Promise.resolve(true);
+      }
+
       return {
         // captureEvent(event: SentryEvent): Promise<SentryResponse>;
         captureEvent: sendEvent, // support for v4 API
         sendEvent, // support for v5 API
+
+        // close(timeout?: number): Promise<boolean>;
+        close,
       }
     },
     initNetworkInterceptor: (dsn, cb) => {

--- a/test/commonTests.js
+++ b/test/commonTests.js
@@ -139,4 +139,11 @@ module.exports.createCommonTests = ({ Sentry, testkit }) => {
     await waitForExpect(() => expect(testkit.reports()).toHaveLength(1))
     expect(testkit.isExist(err)).toBe(true)
   })
+
+  test('should allow flush be called', async function() {
+    const err = new Error('error to look for');
+    Sentry.captureException(err);
+    await waitForExpect(() => expect(testkit.reports()).toHaveLength(1));
+    expect(() => Sentry.flush()).not.toThrow();
+  });
 }


### PR DESCRIPTION
Addresses #21 and #25 by adding a stub for the `close` method which simply resolves a promise. This fixes calling `Sentry.flush` which was throwing:

`TypeError: _this._getBackend(...).getTransport(...).close is not a function`