### PR TITLE
chore: migrate `prepublish` -> `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "docsify serve ./docs",
     "build": "babel src --out-dir dist",
     "test": "jest --config jest.config.json",
-    "prepublish": "npm run-script build",
+    "prepare": "npm run-script build",
     "release": "standard-version"
   },
   "publishConfig": {


### PR DESCRIPTION
Due to deprecation:
```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```