### PR TITLE
fix(types): Add missing generic type arg to default export

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -9,7 +9,7 @@ import {
 
 export = sentryTestkit
 
-declare function sentryTestkit(): sentryTestkit.TestkitResult
+declare function sentryTestkit<T extends sentryTestkit.V6TransportClass | sentryTestkit.V7TransportFunction>(): sentryTestkit.TestkitResult<T>
 
 declare namespace sentryTestkit {
   interface Page {

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ import {
 
 export = sentryTestkit
 
-declare function sentryTestkit(): sentryTestkit.TestkitResult
+declare function sentryTestkit<T extends sentryTestkit.V6TransportClass | sentryTestkit.V7TransportFunction>(): sentryTestkit.TestkitResult<T>
 
 declare namespace sentryTestkit {
   interface Page {


### PR DESCRIPTION
## Description
TypeScript types fix for v4.0.2 (https://github.com/wix/sentry-testkit/pull/116). 

Typechecking using `tsc -b` in my project gives an error `Generic type 'TestkitResult<Transport>' requires 1 type argument(s). ts(2314)`

This PR simply adds the missing generic type args.