### PR TITLE
fix: accept text/plain data

### DIFF
--- a/src/localServerApi.js
+++ b/src/localServerApi.js
@@ -22,7 +22,11 @@ const createLocalServerApi = testkit => {
     // we can't use bodyParser.json() directly
     app.use(
       bodyParser.text({
-        type: ['application/json', 'application/x-sentry-envelope'],
+        type: [
+          'application/json',
+          'application/x-sentry-envelope',
+          'text/plain',
+        ],
       })
     )
     app.post(`/api/${project}/store/`, (req, res) => {

--- a/test/local-server.test.js
+++ b/test/local-server.test.js
@@ -68,6 +68,21 @@ describe('sentry test-kit test suite - local server', function() {
     })
     expect(response.ok).toBe(true)
   })
+
+  test('should handle text/plain encoded items in an envelope request', async function() {
+    const dsn = localServer.getDsn().replace(`/${PROJECT_ID}`, '')
+    const sessionEnvelopeBody =
+      `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.react","version":"6.11.0"}}\n` +
+      `{"type":"session"}\n` +
+      `{"sid":"<removed>","init":false,"started":"2021-08-17T14:27:11.361Z","timestamp":"2021-08-17T14:27:12.489Z","status":"ok","errors":1,"attrs":{"release":"<removed>","environment":"<removed>","user_agent":"<removed>"}}`
+
+    const response = await fetch(`${dsn}/api/${PROJECT_ID}/envelope/`, {
+      method: 'POST',
+      body: sessionEnvelopeBody,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+    expect(response.ok).toBe(true)
+  })
 })
 
 describe('local server testkit error cases', () => {


### PR DESCRIPTION
Sentry is making requests with text/plain content-type which fails to parse without text/plain handler.

Sentry documentation states:

> Envelope requests may contain all headers as regular store requests. The only accepted content-type is application/x-sentry-envelope, which is implied if it is missing. To minimize the necessity for CORS preflights it's acceptable to send text/plain, multipart/form-data and application/x-www-form-urlencoded as well. In either of those cases the behavior however is the same as using application/x-sentry-envelope.
> https://develop.sentry.dev/sdk/envelopes/

It's a bit confused about the use of "the only accepted" but otherwise should be clear that text/plain is also allowed.

Resolves #104