### PR TITLE
fix: allow CORS requests

### DIFF
--- a/src/localServerApi.js
+++ b/src/localServerApi.js
@@ -18,6 +18,10 @@ const createLocalServerApi = testkit => {
 
     const { project } = parseDsn(userDsn)
     const app = express()
+    app.use((req, res, next) => {
+      res.header('Access-Control-Allow-Origin', '*')
+      next()
+    })
     // the performance endpoint uses a custom non-json payload so
     // we can't use bodyParser.json() directly
     app.use(

--- a/test/local-server.test.js
+++ b/test/local-server.test.js
@@ -83,6 +83,22 @@ describe('sentry test-kit test suite - local server', function() {
     })
     expect(response.ok).toBe(true)
   })
+
+  test('responds with Access-Control-Allow-Origin header', async function() {
+    const dsn = localServer.getDsn().replace(`/${PROJECT_ID}`, '')
+    const sessionEnvelopeBody =
+      `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.react","version":"6.11.0"}}\n` +
+      `{"type":"session"}\n` +
+      `{"sid":"<removed>","init":false,"started":"2021-08-17T14:27:11.361Z","timestamp":"2021-08-17T14:27:12.489Z","status":"ok","errors":1,"attrs":{"release":"<removed>","environment":"<removed>","user_agent":"<removed>"}}`
+
+    const response = await fetch(`${dsn}/api/${PROJECT_ID}/envelope/`, {
+      method: 'POST',
+      body: sessionEnvelopeBody,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+    expect(response.ok).toBe(true)
+    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+  })
 })
 
 describe('local server testkit error cases', () => {


### PR DESCRIPTION
When testing in a browser environment, if the request is "non-trivial", the browser will trigger a preflight request first and expect the server to allow it.

The rrweb makes "non-trivial" requests as it uses a mime type that per CORS rules requires a preflight request.

Resolves #105