### PR TITLE
Fix default export when importing in pure node ESM

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
   "preset": "ts-jest",
-  "testMatch": ["**/test/*test.ts"],
+  "testMatch": ["**/test/*test.(j|t)s"],
   "transform": {
     "<rootDir>/.+\\.ts?$": "ts-jest"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createLocalServerApi } from './localServerApi'
 import { createInitNetworkInterceptor } from './initNetworkInterceptor'
 import { createSentryTransport } from './sentryTransport'
 
-export = () => {
+const create = () => {
   const testkit = createTestkit()
   const sentryTransport = createSentryTransport(testkit)
   const initNetworkInterceptor = createInitNetworkInterceptor(testkit)
@@ -16,3 +16,6 @@ export = () => {
     localServer,
   }
 }
+
+create.default = create
+export = create

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createLocalServerApi } from './localServerApi'
 import { createInitNetworkInterceptor } from './initNetworkInterceptor'
 import { createSentryTransport } from './sentryTransport'
 
-export default () => {
+export = () => {
   const testkit = createTestkit()
   const sentryTransport = createSentryTransport(testkit)
   const initNetworkInterceptor = createInitNetworkInterceptor(testkit)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createLocalServerApi } from './localServerApi'
 import { createInitNetworkInterceptor } from './initNetworkInterceptor'
 import { createSentryTransport } from './sentryTransport'
 
-const create = () => {
+function create() {
   const testkit = createTestkit()
   const sentryTransport = createSentryTransport(testkit)
   const initNetworkInterceptor = createInitNetworkInterceptor(testkit)

--- a/test/cjs-require.test.js
+++ b/test/cjs-require.test.js
@@ -1,0 +1,8 @@
+const sentryTestkit = require('../dist/index')
+
+describe('commonjs require', () => {
+  it('should allow to require both default and non-default exports', () => {
+    expect(sentryTestkit()).toBeDefined()
+    expect(sentryTestkit.default()).toBeDefined()
+  })
+})

--- a/test/esm-require.test.ts
+++ b/test/esm-require.test.ts
@@ -1,0 +1,10 @@
+import execa from 'execa'
+
+describe('es modules require', () => {
+  it('should allow to import as native esm', () => {
+    // test will fail if the command fails
+    execa.commandSync('node --experimental-vm-modules test/fixtures/esm.mjs', {
+      stdio: 'inherit',
+    })
+  })
+})

--- a/test/fixtures/esm.mjs
+++ b/test/fixtures/esm.mjs
@@ -1,0 +1,3 @@
+import sentryTestkit from '../../dist/index.js'
+
+sentryTestkit()


### PR DESCRIPTION
Importing sentry-testkit in a pure ESM node project currently fails as the default export doesn't conform to what node expects.

Sample node code:
```js
import sentryTestkit from 'sentry-testkit';

sentryTestkit()
```

Running the above with an ESM package and `node --experimental-vm-modules` will result in `TypeError: sentryTestkit is not a function`


According to node docs, a commonjs default export  should be `module.exports = X`, but for sentry-testkit TS emits `exports.default = X`. I assume this is related to legacy/browser ESM and backward compatibility, but I don't know enough about this subject.
EDIT: Indeed this is related to ES6 modules standard: https://stackoverflow.com/a/50948000

This PR changes the export according to the [TS docs](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require).

EDIT: Changed the code to preserve compatibility with `const createTestkit = require('sentry-testkit').default`
According to this article: https://remarkablemark.org/blog/2020/05/05/typescript-export-commonjs-es6-modules/