### PR TITLE
fix: local server not capturing error events from the browser

### DIFF
--- a/src/initNetworkInterceptor.ts
+++ b/src/initNetworkInterceptor.ts
@@ -1,5 +1,5 @@
-import { parseDsn, parseEnvelopeRequest } from './parsers'
-import { transformReport, transformTransaction } from './transformers'
+import { handleEnvelopeRequestData, parseDsn } from './parsers'
+import { transformReport } from './transformers'
 import { Testkit } from './types'
 
 export type InterceptorCallback = (
@@ -15,15 +15,7 @@ export function createInitNetworkInterceptor(testkit: Testkit) {
     const handleRequestBody = (requestBody: any) =>
       testkit.reports().push(transformReport(requestBody))
     const handleEnvelopeRequestBody = (requestBody: any) => {
-      const { type, payload } = parseEnvelopeRequest(requestBody)
-
-      if (type === 'transaction') {
-        testkit.transactions().push(transformTransaction(payload))
-      }
-
-      if (type === 'event') {
-        testkit.reports().push(transformReport(payload))
-      }
+      handleEnvelopeRequestData(requestBody, testkit)
     }
 
     return cb(baseUrl, handleRequestBody, handleEnvelopeRequestBody)

--- a/src/localServerApi.ts
+++ b/src/localServerApi.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import http from 'http'
-import { parseDsn, parseEnvelopeRequest } from './parsers'
-import { transformReport, transformTransaction } from './transformers'
+import { parseDsn, handleEnvelopeRequestData } from './parsers'
+import { transformReport } from './transformers'
 import { Testkit } from './types'
 
 export function createLocalServerApi(testkit: Testkit) {
@@ -43,25 +43,11 @@ export function createLocalServerApi(testkit: Testkit) {
           rawData += chunk
         })
         req.on('end', () => {
-          const { type, payload } = parseEnvelopeRequest(rawData)
-
-          if (type === 'transaction') {
-            testkit.transactions().push(transformTransaction(payload))
-          }
-
-          if (type === 'event') {
-            testkit.reports().push(transformReport(payload))
-          }
-
+          handleEnvelopeRequestData(rawData, testkit)
           res.sendStatus(200)
         })
       } else {
-        const { type, payload } = parseEnvelopeRequest(req.body)
-
-        if (type === 'transaction') {
-          testkit.transactions().push(transformTransaction(payload))
-        }
-
+        handleEnvelopeRequestData(req.body, testkit)
         res.sendStatus(200)
       }
     })

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,3 +1,6 @@
+import { transformReport, transformTransaction } from './transformers'
+import { Testkit } from './types'
+
 const dsnKeys = 'source protocol user pass host port path'.split(' ')
 const dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/ //eslint-disable-line no-useless-escape
 
@@ -28,5 +31,18 @@ export function parseEnvelopeRequest(reqBody: string) {
   return {
     type: JSON.parse(itemHeader!).type,
     payload: JSON.parse(itemPayload!),
+  }
+}
+
+export function handleEnvelopeRequestData(
+  requestBody: any,
+  testkit: Testkit
+): void {
+  const { type, payload } = parseEnvelopeRequest(requestBody)
+
+  if (type === 'transaction') {
+    testkit.transactions().push(transformTransaction(payload))
+  } else if (type === 'event') {
+    testkit.reports().push(transformReport(payload))
   }
 }


### PR DESCRIPTION
Support for capturing error events sent from the Browser (as opposed to from the Node) was missing. When browser makes a POST request to the server, the `transfer-encoding: chunked` encoding is not used and the block that handled that case was missing error parsing and adding to `reports()`.

While at it, I've consolidated 3 places that did the request body parsing and event processing into single exported function. This should hopefully ensure that no one forgets about handling one of the places in the future as there will be only one place to change. (Let me know if this new function should live somewhere else).

I've looked into adding test for this case but that would require a setup for testing using real browser and that would require quite a bit of work to set up and those tests would significantly slow down the testsuite.