### PR TITLE
fix: support all content types in local server endpoints

### DIFF
--- a/src/initNetworkInterceptor.ts
+++ b/src/initNetworkInterceptor.ts
@@ -1,5 +1,5 @@
-import { parseDsn, parseEnvelopeRequest } from './parsers'
-import { transformReport, transformTransaction } from './transformers'
+import { handleEnvelopeRequestData, parseDsn } from './parsers'
+import { transformReport } from './transformers'
 import { Testkit } from './types'
 
 export type InterceptorCallback = (
@@ -15,15 +15,7 @@ export function createInitNetworkInterceptor(testkit: Testkit) {
     const handleRequestBody = (requestBody: any) =>
       testkit.reports().push(transformReport(requestBody))
     const handleEnvelopeRequestBody = (requestBody: any) => {
-      const { type, payload } = parseEnvelopeRequest(requestBody)
-
-      if (type === 'transaction') {
-        testkit.transactions().push(transformTransaction(payload))
-      }
-
-      if (type === 'event') {
-        testkit.reports().push(transformReport(payload))
-      }
+      handleEnvelopeRequestData(requestBody, testkit)
     }
 
     return cb(baseUrl, handleRequestBody, handleEnvelopeRequestBody)

--- a/src/localServerApi.ts
+++ b/src/localServerApi.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import http from 'http'
-import { parseDsn, parseEnvelopeRequest } from './parsers'
-import { transformReport, transformTransaction } from './transformers'
+import { parseDsn, handleEnvelopeRequestData } from './parsers'
+import { transformReport } from './transformers'
 import { Testkit } from './types'
 
 export function createLocalServerApi(testkit: Testkit) {
@@ -43,25 +43,11 @@ export function createLocalServerApi(testkit: Testkit) {
           rawData += chunk
         })
         req.on('end', () => {
-          const { type, payload } = parseEnvelopeRequest(rawData)
-
-          if (type === 'transaction') {
-            testkit.transactions().push(transformTransaction(payload))
-          }
-
-          if (type === 'event') {
-            testkit.reports().push(transformReport(payload))
-          }
-
+          handleEnvelopeRequestData(rawData, testkit)
           res.sendStatus(200)
         })
       } else {
-        const { type, payload } = parseEnvelopeRequest(req.body)
-
-        if (type === 'transaction') {
-          testkit.transactions().push(transformTransaction(payload))
-        }
-
+        handleEnvelopeRequestData(req.body, testkit)
         res.sendStatus(200)
       }
     })

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,3 +1,6 @@
+import { transformReport, transformTransaction } from './transformers'
+import { Testkit } from './types'
+
 const dsnKeys = 'source protocol user pass host port path'.split(' ')
 const dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/ //eslint-disable-line no-useless-escape
 
@@ -28,5 +31,18 @@ export function parseEnvelopeRequest(reqBody: string) {
   return {
     type: JSON.parse(itemHeader!).type,
     payload: JSON.parse(itemPayload!),
+  }
+}
+
+export function handleEnvelopeRequestData(
+  requestBody: any,
+  testkit: Testkit
+): void {
+  const { type, payload } = parseEnvelopeRequest(requestBody)
+
+  if (type === 'transaction') {
+    testkit.transactions().push(transformTransaction(payload))
+  } else if (type === 'event') {
+    testkit.reports().push(transformReport(payload))
   }
 }


### PR DESCRIPTION
This PR is based on https://github.com/wix/sentry-testkit/pull/152 so should be handled after the other one. The diff will become much smaller then.

This change removes all content-type restrictions for the bodyParser middleware. The reason for that is that I found a case that is not properly handled. For Node-side events whose size is [over the threshold](https://github.com/getsentry/sentry-javascript/blob/c59c70bfc636de9bd7512f37e9644db1947a5563/packages/node/src/transports/http.ts#L30-L31) Sentry will send those gzip-compressed but without content-type. That meant that those were not processed by `bodyParser` and we entered the block that does manual body processing but that failed due to not handling `gziped` content.

To solve that, removed custom body parsing code and enabled `bodyParser` for all content types.