### PR TITLE
fix: correct typo in homepage footer

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -107,7 +107,7 @@ export default function Home(): JSX.Element {
           <div className={styles.gettingReady}>
             Testing error reporting doesn't have to be painful.
             <br />
-            Setnry-Testkit will help you write less code while achieving better
+            Sentry-Testkit will help you write less code while achieving better
             performance.
           </div>
           <div className={styles.getStartedButtons}>


### PR DESCRIPTION
<img width="1492" height="350" alt="image" src="https://github.com/user-attachments/assets/f01e3fb1-e60c-41f1-a2bf-d44b45f74da9" />
