### PR TITLE
fix(parser): support multi-item envelopes

### DIFF
--- a/packages/sentry-testkit-docs/docs/network-interception.md
+++ b/packages/sentry-testkit-docs/docs/network-interception.md
@@ -16,6 +16,7 @@ The interceptor should intercept requests from `baseUrl` and pass the request bo
 For envelope requests (such as performance events), we use the emitted request event,
 since in a reply function nock automatically tries to parse the body as json,
 and fails since Sentry are using a non-standard json with a json request header.
+Envelope requests may carry multiple items (for example an error event batched together with a session update) — the testkit parses **all** items of an envelope and captures every supported item type, regardless of its position in the envelope.
 :::info
 See https://develop.sentry.dev/sdk/envelopes/ for more information on envelope requests.
 :::

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -1,0 +1,121 @@
+import { parseEnvelope, handleEnvelopeRequestData } from '../src/parsers'
+import { createTestkit } from '../src/testkit'
+
+const envelopeHeader = `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.node","version":"6.11.0"}}`
+const eventPayload = `{"exception":{"values":[{"type":"Error","value":"testing error"}]},"level":"error","tags":{}}`
+const transactionPayload = `{"type":"transaction","transaction":"test-transaction","contexts":{"trace":{"trace_id":"1234","span_id":"5678"}},"spans":[]}`
+const sessionPayload = `{"sid":"abc","init":false,"started":"2021-08-17T14:27:11.361Z","status":"ok","errors":1}`
+
+describe('parseEnvelope', () => {
+  test('parses a single-item event envelope', () => {
+    const body = `${envelopeHeader}\n{"type":"event"}\n${eventPayload}`
+
+    const items = parseEnvelope(body)
+
+    expect(items).toHaveLength(1)
+    expect(items[0]!.header.type).toBe('event')
+    expect(items[0]!.payload.level).toBe('error')
+  })
+
+  test('parses all items of a multi-item envelope', () => {
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"session"}\n${sessionPayload}\n` +
+      `{"type":"event"}\n${eventPayload}\n` +
+      `{"type":"client_report"}\n{"timestamp":123,"discarded_events":[]}`
+
+    const items = parseEnvelope(body)
+
+    expect(items.map(item => item.header.type)).toEqual([
+      'session',
+      'event',
+      'client_report',
+    ])
+  })
+
+  test('honors the length field for payloads containing newlines', () => {
+    const payloadWithNewlines = 'first line\nsecond line'
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"attachment","filename":"log.txt","length":${payloadWithNewlines.length}}\n` +
+      `${payloadWithNewlines}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    const items = parseEnvelope(body)
+
+    expect(items).toHaveLength(2)
+    expect(items[0]!.payload).toBe(payloadWithNewlines)
+    expect(items[1]!.header.type).toBe('event')
+  })
+
+  test('measures length in bytes for multi-byte characters', () => {
+    const payload = 'שלום'
+    const byteLength = Buffer.byteLength(payload)
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"attachment","length":${byteLength}}\n` +
+      `${payload}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    const items = parseEnvelope(body)
+
+    expect(items).toHaveLength(2)
+    expect(items[0]!.payload).toBe(payload)
+    expect(items[1]!.header.type).toBe('event')
+  })
+
+  test('keeps non-JSON payloads as raw strings', () => {
+    const body = `${envelopeHeader}\n{"type":"attachment"}\nplain text attachment`
+
+    const items = parseEnvelope(body)
+
+    expect(items[0]!.payload).toBe('plain text attachment')
+  })
+
+  test('tolerates a trailing newline at the end of the envelope', () => {
+    const body = `${envelopeHeader}\n{"type":"event"}\n${eventPayload}\n`
+
+    const items = parseEnvelope(body)
+
+    expect(items).toHaveLength(1)
+    expect(items[0]!.header.type).toBe('event')
+  })
+})
+
+describe('handleEnvelopeRequestData', () => {
+  test('captures an event even when it is not the first envelope item', () => {
+    const testkit = createTestkit()
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"session"}\n${sessionPayload}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.reports()).toHaveLength(1)
+    expect(testkit.getExceptionAt(0)!.message).toBe('testing error')
+  })
+
+  test('routes multiple items from a single envelope', () => {
+    const testkit = createTestkit()
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"event"}\n${eventPayload}\n` +
+      `{"type":"transaction"}\n${transactionPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.reports()).toHaveLength(1)
+    expect(testkit.transactions()).toHaveLength(1)
+    expect(testkit.transactions()[0]!.name).toBe('test-transaction')
+  })
+
+  test('ignores unknown item types without throwing', () => {
+    const testkit = createTestkit()
+    const body = `${envelopeHeader}\n{"type":"session"}\n${sessionPayload}`
+
+    expect(() => handleEnvelopeRequestData(body, testkit)).not.toThrow()
+    expect(testkit.reports()).toHaveLength(0)
+    expect(testkit.transactions()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -26,23 +26,103 @@ export function parseDsn(dsn: string) {
   return { protocol, project, host }
 }
 
-export function parseEnvelopeRequest(reqBody: string) {
-  const [_header, itemHeader, itemPayload] = reqBody.split('\n')
-  return {
-    type: JSON.parse(itemHeader!).type,
-    payload: JSON.parse(itemPayload!),
+export interface EnvelopeItemHeader {
+  type?: string
+  length?: number
+  [key: string]: any
+}
+
+export interface EnvelopeItem {
+  header: EnvelopeItemHeader
+  payload: any
+}
+
+const NEWLINE = 0x0a
+
+// Buffer in Node.js, TextEncoder/TextDecoder in browsers (Puppeteer page context)
+function toBytes(input: string | Uint8Array): Uint8Array {
+  if (typeof input !== 'string') {
+    return input
   }
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(input)
+    : new TextEncoder().encode(input)
+}
+
+function fromBytes(bytes: Uint8Array): string {
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(bytes).toString()
+    : new TextDecoder().decode(bytes)
+}
+
+// Envelope format: https://develop.sentry.dev/sdk/data-model/envelopes/
+// <envelope header>\n(<item header>\n<item payload>\n)*
+// An item header may declare `length` (payload size in bytes), in which case
+// the payload may contain newlines or binary data.
+export function parseEnvelope(rawBody: string | Uint8Array): EnvelopeItem[] {
+  const bytes = toBytes(rawBody)
+  const items: EnvelopeItem[] = []
+
+  const readLine = (from: number) => {
+    let end = from
+    while (end < bytes.length && bytes[end] !== NEWLINE) {
+      end++
+    }
+    return {
+      line: fromBytes(bytes.subarray(from, end)),
+      next: end + 1,
+    }
+  }
+
+  // Skip the envelope header line
+  let offset = readLine(0).next
+
+  while (offset < bytes.length) {
+    const { line: headerLine, next } = readLine(offset)
+    if (headerLine.trim() === '') {
+      // Tolerate trailing newlines at the end of the envelope
+      offset = next
+      continue
+    }
+    const header = JSON.parse(headerLine)
+
+    let rawPayload: string
+    if (typeof header.length === 'number') {
+      rawPayload = fromBytes(bytes.subarray(next, next + header.length))
+      offset = next + header.length
+      // Skip the newline separating this payload from the next item header
+      if (bytes[offset] === NEWLINE) {
+        offset++
+      }
+    } else {
+      const payloadLine = readLine(next)
+      rawPayload = payloadLine.line
+      offset = payloadLine.next
+    }
+
+    let payload: any
+    try {
+      payload = JSON.parse(rawPayload)
+    } catch {
+      // Non-JSON payloads (e.g. attachments, replay recordings) stay raw
+      payload = rawPayload
+    }
+
+    items.push({ header, payload })
+  }
+
+  return items
 }
 
 export function handleEnvelopeRequestData(
   requestBody: any,
   testkit: Testkit
 ): void {
-  const { type, payload } = parseEnvelopeRequest(requestBody)
-
-  if (type === 'transaction') {
-    testkit.transactions().push(transformTransaction(payload))
-  } else if (type === 'event') {
-    testkit.reports().push(transformReport(payload))
-  }
+  parseEnvelope(requestBody).forEach(({ header, payload }) => {
+    if (header.type === 'transaction') {
+      testkit.transactions().push(transformTransaction(payload))
+    } else if (header.type === 'event') {
+      testkit.reports().push(transformReport(payload))
+    }
+  })
 }

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -1,4 +1,4 @@
-import { parseEnvelopeRequest } from './parsers'
+import { parseEnvelope } from './parsers'
 import { transformReport, transformTransaction } from './transformers'
 import { Report, ReportError, Testkit, Transaction } from './types'
 
@@ -21,12 +21,13 @@ export function createTestkit(): Testkit {
       reports.push(transformReport(JSON.parse(request.postData())))
     }
     if (/\/api\/[0-9]*\/envelope/.test(path)) {
-      const { type, payload } = parseEnvelopeRequest(request.postData())
-      if (type === 'transaction') {
-        transactions.push(transformTransaction(payload))
-      } else if (type === 'event') {
-        reports.push(transformReport(payload))
-      }
+      parseEnvelope(request.postData()).forEach(({ header, payload }) => {
+        if (header.type === 'transaction') {
+          transactions.push(transformTransaction(payload))
+        } else if (header.type === 'event') {
+          reports.push(transformReport(payload))
+        }
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

`parseEnvelopeRequest` split the raw envelope on newlines and only ever read the **first** item, so:

- envelopes where the event is not the first item lost the event (real data loss in the local-server, network-interceptor, and Puppeteer modes);
- multi-item envelopes (e.g. event batched with a session update) were truncated to one item;
- `length`-prefixed payloads (which may contain newlines or binary data) broke the line-based assumption.

This PR replaces it with `parseEnvelope`, which parses **all** items per the [envelope spec](https://develop.sentry.dev/sdk/data-model/envelopes/):

- byte-accurate handling of the item header `length` field (works in Node via `Buffer` and in browser contexts via `TextEncoder`/`TextDecoder` — the package keeps its zero Sentry-runtime-dependency footprint);
- non-JSON payloads (attachments, replay recordings) are kept as raw strings;
- trailing newlines tolerated.

Routing behavior is unchanged: `event` → reports, `transaction` → transactions, everything else ignored. This is the prerequisite (#299) for capturing the new item types tracked in #313.

## Test plan

- New `__tests__/parsers.test.ts` unit suite: multi-item envelopes, event-not-first (the bug-fix case), `length` payloads containing newlines, multi-byte length accounting, non-JSON fallback, trailing newline.
- Full suite green: 10 suites, 125 tests (`yarn build`, `yarn lint`, `yarn test`).
- Docs: clarified multi-item behavior in `network-interception.md`; `yarn workspace sentry-testkit-docs build` passes.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)