### PR TITLE
feat(logs)!: capture structured logs via testkit.logs()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        sentry-version: [^8.0.0, ^9.0.0, ^10.0.0]
+        sentry-version: [^9.0.0, ^10.0.0]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 </p>
 <p align="center">
 <a href="#">
-    <img src="https://img.shields.io/badge/Compatible%20with%20Sentry-v8-blue" alt="sentry version 8">
-  </a>
-<a href="#">
     <img src="https://img.shields.io/badge/Compatible%20with%20Sentry-v9-blue" alt="sentry version 9">
   </a>
 <a href="#">

--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -129,6 +129,34 @@ test('transactions example', async function() {
 })
 ```
 
+### `logs()`
+Gets all captured [structured logs](https://docs.sentry.io/platforms/javascript/logs/) (requires `enableLogs: true` in `Sentry.init`).
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>Log</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `level` | <code>string</code> | `trace` \| `debug` \| `info` \| `warn` \| `error` \| `fatal` |
+| `message` | <code>string</code> | The log body |
+| `attributes` | <code>Object</code> | Log attributes as plain values, e.g. `{ userId: 42 }` |
+| `timestamp` | <code>number</code> | Epoch time in seconds |
+| `traceId` | <code>string</code> | The trace this log belongs to, if any |
+| `severityNumber` | <code>number</code> | The numeric severity, if any |
+| `originalLog` | <code>Object</code> | The raw log item as sent by the SDK |
+
+For example
+```javascript
+test('logs example', async function() {
+    Sentry.logger.info('user logged in', { userId: 42 })
+    await Sentry.flush()
+
+    const [log] = testkit.logs()
+    expect(log.level).toEqual('info')
+    expect(log.message).toEqual('user logged in')
+    expect(log.attributes.userId).toEqual(42)
+})
+```
+
 ### `reset()`
 Resets the testkit state and clear all existing reports.
 

--- a/packages/sentry-testkit-docs/docs/migration/sentry-v10.md
+++ b/packages/sentry-testkit-docs/docs/migration/sentry-v10.md
@@ -27,6 +27,7 @@ If you are upgrading your application to Sentry v10, be aware of the [official m
 | sentry-testkit | Sentry JS SDK (browser / node / react) |
 |----------------|----------------------------------------|
 | 6.x            | v8, v9, v10                             |
+| 7.x            | v9, v10                                 |
 
 For React Native, use `@sentry/react-native` with a version that matches your chosen Sentry JavaScript SDK line (see [Sentry React Native docs](https://docs.sentry.io/platforms/react-native/)).
 

--- a/packages/sentry-testkit-docs/docs/migration/version-7.md
+++ b/packages/sentry-testkit-docs/docs/migration/version-7.md
@@ -1,0 +1,55 @@
+# Version 7 Migration Guide
+
+`sentry-testkit` version 7 is a major release. It introduces support for Sentry's structured logs and drops support for Sentry SDK v8. This guide will help you to migrate your existing codebase to the new version.
+
+## Added Features
+
+### Structured Logs support — `testkit.logs()`
+
+Version 7 introduces support for [Sentry structured logs](https://docs.sentry.io/platforms/javascript/logs/). Logs sent via `Sentry.logger.*` are captured in all integration modes (transport, local server, network interception, and Puppeteer) and can be asserted on with the new `testkit.logs()` API:
+
+```javascript
+Sentry.init({
+  dsn: '<your DSN>',
+  transport: sentryTransport,
+  enableLogs: true,
+})
+
+test('logs example', async function() {
+    Sentry.logger.info('user logged in', { userId: 42 })
+    await Sentry.flush()
+
+    const [log] = testkit.logs()
+    expect(log.level).toEqual('info')
+    expect(log.message).toEqual('user logged in')
+    expect(log.attributes.userId).toEqual(42)
+})
+```
+
+See the [`logs()` API reference](/docs/api#logs) for the full shape of the captured `Log` object.
+
+### Multi-item envelope parsing
+
+The testkit now parses **all** items of a Sentry envelope instead of only the first one. Events and transactions are captured regardless of their position in the envelope — for example, an error event batched together with a session update is no longer dropped. This also lays the groundwork for capturing more Sentry data types (user feedback, cron check-ins, sessions, replays, and more) in upcoming releases.
+
+## Breaking Changes
+
+### Dropped Sentry SDK v8 support
+
+Starting from version 7, `sentry-testkit` only supports Sentry SDKs for JavaScript packages at **version 9 and above**. The structured logs API (`Sentry.logger`) that powers `testkit.logs()` does not exist in Sentry v8.
+
+If you are using Sentry SDK v8, you have two options:
+
+- **Upgrade** your `@sentry/*` packages to v9 or v10 (see the official [v8 to v9 migration guide](https://docs.sentry.io/platforms/javascript/migration/v8-to-v9/)), or
+- **Stay** on `sentry-testkit@6`, which continues to support Sentry v8, v9, and v10.
+
+### Compatibility matrix
+
+| sentry-testkit | Sentry JS SDK (browser / node / react) |
+|----------------|----------------------------------------|
+| 6.x            | v8, v9, v10                             |
+| 7.x            | v9, v10                                 |
+
+## No other API changes
+
+The rest of the testkit API is unchanged — `reports()`, `transactions()`, `findReport()`, `isExist()`, `getExceptionAt()`, `reset()`, and all integration modes work exactly as they did in version 6. No changes are required in your existing test code.

--- a/packages/sentry-testkit/__tests__/logs.test.ts
+++ b/packages/sentry-testkit/__tests__/logs.test.ts
@@ -1,0 +1,77 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+describe('sentry test-kit test suite - structured logs', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      enableLogs: true,
+      transport: sentryTransport,
+    })
+  )
+
+  beforeEach(() => testkit.reset())
+
+  test('logs() is empty when nothing was logged', () => {
+    expect(testkit.logs()).toEqual([])
+  })
+
+  test('captures a log with level, message and timestamp', async () => {
+    Sentry.logger.info('user logged in')
+    await Sentry.flush()
+
+    expect(testkit.logs()).toHaveLength(1)
+    const log = testkit.logs()[0]!
+    expect(log.level).toBe('info')
+    expect(log.message).toBe('user logged in')
+    expect(log.timestamp).toEqual(expect.any(Number))
+  })
+
+  test('unwraps typed attributes to plain values', async () => {
+    Sentry.logger.warn('quota almost exceeded', {
+      userId: 42,
+      plan: 'free',
+      active: true,
+    })
+    await Sentry.flush()
+
+    expect(testkit.logs()).toHaveLength(1)
+    const log = testkit.logs()[0]!
+    expect(log.level).toBe('warn')
+    expect(log.attributes['userId']).toBe(42)
+    expect(log.attributes['plan']).toBe('free')
+    expect(log.attributes['active']).toBe(true)
+  })
+
+  test('captures multiple logs in order with their levels', async () => {
+    Sentry.logger.debug('first')
+    Sentry.logger.error('second')
+    await Sentry.flush()
+
+    expect(testkit.logs().map(log => log.level)).toEqual(['debug', 'error'])
+    expect(testkit.logs().map(log => log.message)).toEqual(['first', 'second'])
+  })
+
+  test('exposes the raw serialized log as originalLog', async () => {
+    Sentry.logger.info('raw access')
+    await Sentry.flush()
+
+    const log = testkit.logs()[0]!
+    expect(log.originalLog.body).toBe('raw access')
+    expect(log.originalLog.level).toBe('info')
+  })
+
+  test('reset() clears captured logs', async () => {
+    Sentry.logger.info('to be cleared')
+    await Sentry.flush()
+    expect(testkit.logs()).toHaveLength(1)
+
+    testkit.reset()
+
+    expect(testkit.logs()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/__tests__/network-interception.test.ts
+++ b/packages/sentry-testkit/__tests__/network-interception.test.ts
@@ -47,6 +47,14 @@ describe('sentry test-kit test suite - network interception', function() {
     })
   })
 
+  afterAll(() => {
+    // Jest reuses worker processes across test files — leaving net connect
+    // disabled breaks suites that talk to a real local server afterwards
+    nock.cleanAll()
+    nock.enableNetConnect()
+    nock.restore()
+  })
+
   beforeEach(() => testkit.reset())
 
   createCommonTests({ Sentry, testkit })

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -110,6 +110,40 @@ describe('handleEnvelopeRequestData', () => {
     expect(testkit.transactions()[0]!.name).toBe('test-transaction')
   })
 
+  test('captures logs from a log container item', () => {
+    const testkit = createTestkit()
+    const logItems = JSON.stringify({
+      items: [
+        {
+          timestamp: 1717081538.235,
+          level: 'info',
+          body: 'user logged in',
+          trace_id: 'abcd1234',
+          attributes: { userId: { value: 42, type: 'integer' } },
+        },
+        {
+          timestamp: 1717081539.001,
+          level: 'error',
+          body: 'something failed',
+        },
+      ],
+    })
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"log","item_count":2,"content_type":"application/vnd.sentry.items.log+json"}\n` +
+      `${logItems}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.logs()).toHaveLength(2)
+    expect(testkit.logs()[0]!.message).toBe('user logged in')
+    expect(testkit.logs()[0]!.traceId).toBe('abcd1234')
+    expect(testkit.logs()[0]!.attributes['userId']).toBe(42)
+    expect(testkit.logs()[1]!.level).toBe('error')
+    expect(testkit.reports()).toHaveLength(1)
+  })
+
   test('ignores unknown item types without throwing', () => {
     const testkit = createTestkit()
     const body = `${envelopeHeader}\n{"type":"session"}\n${sessionPayload}`

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -1,4 +1,8 @@
-import { transformReport, transformTransaction } from './transformers'
+import {
+  transformLog,
+  transformReport,
+  transformTransaction,
+} from './transformers'
 import { Testkit } from './types'
 
 const dsnKeys = 'source protocol user pass host port path'.split(' ')
@@ -123,6 +127,10 @@ export function handleEnvelopeRequestData(
       testkit.transactions().push(transformTransaction(payload))
     } else if (header.type === 'event') {
       testkit.reports().push(transformReport(payload))
+    } else if (header.type === 'log') {
+      // Log items are containers: their payload is { items: SerializedLog[] }
+      const logs = (payload && payload.items) || []
+      logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
     }
   })
 }

--- a/packages/sentry-testkit/src/sentryTransport.ts
+++ b/packages/sentry-testkit/src/sentryTransport.ts
@@ -1,5 +1,9 @@
 import { Event } from '@sentry/types'
-import { transformReport, transformTransaction } from './transformers'
+import {
+  transformLog,
+  transformReport,
+  transformTransaction,
+} from './transformers'
 import { Testkit } from './types'
 
 export function createSentryTransport(testkit: Testkit): any {
@@ -28,6 +32,10 @@ export function createSentryTransport(testkit: Testkit): any {
           testkit.transactions().push(transformTransaction(data))
         } else if (headers.type === 'event') {
           testkit.reports().push(transformReport(data))
+        } else if (headers.type === 'log') {
+          // Log items are containers: their payload is { items: SerializedLog[] }
+          const logs = (data && data.items) || []
+          logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
         }
       })
 

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -1,6 +1,10 @@
 import { parseEnvelope } from './parsers'
-import { transformReport, transformTransaction } from './transformers'
-import { Report, ReportError, Testkit, Transaction } from './types'
+import {
+  transformLog,
+  transformReport,
+  transformTransaction,
+} from './transformers'
+import { Log, Report, ReportError, Testkit, Transaction } from './types'
 
 function getException(report: Report) {
   return report.error
@@ -9,6 +13,7 @@ function getException(report: Report) {
 export function createTestkit(): Testkit {
   let reports: Report[] = []
   let transactions: Transaction[] = []
+  let logs: Log[] = []
 
   let puppeteerHandler: any = null
   const createPuppeteerHandler = (baseUrl: string) => (request: any) => {
@@ -26,6 +31,9 @@ export function createTestkit(): Testkit {
           transactions.push(transformTransaction(payload))
         } else if (header.type === 'event') {
           reports.push(transformReport(payload))
+        } else if (header.type === 'log') {
+          const items = (payload && payload.items) || []
+          items.forEach((log: any) => logs.push(transformLog(log)))
         }
       })
     }
@@ -51,9 +59,14 @@ export function createTestkit(): Testkit {
       return transactions
     },
 
+    logs() {
+      return logs
+    },
+
     reset() {
       reports = []
       transactions = []
+      logs = []
     },
 
     getExceptionAt(index: number) {

--- a/packages/sentry-testkit/src/transformers.ts
+++ b/packages/sentry-testkit/src/transformers.ts
@@ -1,4 +1,4 @@
-import { Report, ReportError, Transaction } from './types'
+import { Log, Report, ReportError, Transaction } from './types'
 
 export function transformReport(report: any): Report {
   const exception =
@@ -21,6 +21,28 @@ export function transformReport(report: any): Report {
     user: report.user,
     tags: report.tags || {},
     originalReport: report,
+  }
+}
+
+export function transformLog(log: any): Log {
+  // Serialized log attributes are typed wrappers, e.g. { value: 42, type: 'integer' }
+  const attributes: { [key: string]: any } = {}
+  Object.keys(log.attributes || {}).forEach(key => {
+    const attribute = log.attributes[key]
+    attributes[key] =
+      attribute && typeof attribute === 'object' && 'value' in attribute
+        ? attribute.value
+        : attribute
+  })
+
+  return {
+    level: log.level,
+    message: log.body,
+    attributes,
+    timestamp: log.timestamp,
+    traceId: log.trace_id,
+    severityNumber: log.severity_number,
+    originalLog: log,
   }
 }
 

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -3,6 +3,7 @@ import {
   Breadcrumb,
   User,
   SeverityLevel,
+  LogSeverityLevel,
   Stacktrace,
   Transport,
   SpanAttributes,
@@ -64,6 +65,16 @@ declare namespace sentryTestkit {
     user?: User
   }
 
+  interface Log {
+    level: LogSeverityLevel
+    message: string
+    attributes: { [key: string]: any }
+    timestamp: number
+    traceId?: string
+    severityNumber?: number
+    originalLog: any
+  }
+
   export interface Testkit {
     puppeteer: {
       startListening(page: Page, baseUrl?: string): void
@@ -71,6 +82,7 @@ declare namespace sentryTestkit {
     }
     reports(): Report[]
     transactions(): Transaction[]
+    logs(): Log[]
     reset(): void
     getExceptionAt(index: number): ReportError | undefined
     findReport(e: Error): Report | undefined


### PR DESCRIPTION
## Summary

Implements #300: Sentry [structured logs](https://docs.sentry.io/platforms/javascript/logs/) (`Sentry.logger.info(...)` etc.) are sent as `log` container envelope items with payload `{ items: SerializedLog[] }`. The testkit now captures them in **all four integration modes** — custom transport, local server, network interceptor, and Puppeteer — and exposes them via a new `testkit.logs()` API.

Each captured `Log` exposes:

- `level`, `message` (the log body), `timestamp`, `traceId`, `severityNumber`
- `attributes` unwrapped to plain values (`{ userId: 42 }` instead of the SDK's `{ userId: { value: 42, type: 'integer' } }`)
- `originalLog` — the raw serialized item, mirroring the `originalReport` pattern

`testkit.reset()` clears captured logs.

Builds on the multi-item envelope parser from #314 (log containers ride in multi-item envelopes).

## 💥 BREAKING CHANGE: drops sentry@8 support

The `Sentry.logger` API and the `LogSeverityLevel` type only exist in `@sentry/*` v9+, so sentry@8 is removed from the CI test matrix (`tests.yml` now covers `^9.0.0` and `^10.0.0`) and the v8 compatibility badge is removed from the README. Squash-merge must keep the `feat(logs)!:` prefix and the `BREAKING CHANGE:` footer so release-please cuts a major release.

## Also included

- Test hygiene fix: `nock.enableNetConnect()`/`restore()` after the network-interception suite — Jest reuses worker processes, and the leaked disabled-net-connect state made local-server tests fail depending on scheduling order.

## Test plan

- New `__tests__/logs.test.ts`: end-to-end through `@sentry/node` v10 with `enableLogs: true` — capture, attribute unwrapping, ordering, `originalLog`, `reset()`.
- New case in `__tests__/parsers.test.ts`: raw-envelope routing of a log container (local-server/interceptor/Puppeteer path) alongside an event item.
- Full suite green: 11 suites, 132 tests (`yarn build`, `yarn lint`, `yarn test`, verified with `--runInBand` too).
- Docs: new `logs()` section in the API reference; `yarn workspace sentry-testkit-docs build` passes.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)