### PR TITLE
ci: use npm trusted publishing (OIDC) for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,11 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm trusted publishing (OIDC):
+      # https://docs.npmjs.com/trusted-publishers
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +41,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1; Node 22 bundles npm 10
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -47,7 +56,8 @@ jobs:
       - name: Test
         run: yarn workspace sentry-testkit test
 
+      # npm CLI (not yarn) so OIDC authentication and provenance are used;
+      # no token needed — auth comes from the trusted publisher configuration
       - name: Publish to npm
-        run: yarn workspace sentry-testkit npm publish --access public
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: ./packages/sentry-testkit
+        run: npm publish --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ Release process:
 - once the Release PR is merged, release-please creates a GitHub release and a git tag;
 - the CI workflow then builds, tests, and publishes the package to npm automatically.
 
+Publishing uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC): the workflow authenticates via a short-lived token issued to the `release-please.yml` workflow — no `NPM_TOKEN` secret is involved — and npm generates provenance attestations for every release. The trusted publisher configuration lives on npmjs.com (package settings → Trusted Publisher) and is tied to this repository and workflow filename, so renaming `release-please.yml` requires updating that configuration too.
+
 No manual steps are required. The version bump is determined by the commit types on `master`:
 
 | Commit type | Version bump |

--- a/packages/sentry-testkit/package.json
+++ b/packages/sentry-testkit/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:zivl/sentry-testkit.git"
+    "url": "git+https://github.com/zivl/sentry-testkit.git"
   },
   "keywords": [
     "raven-test-kit",


### PR DESCRIPTION
## Summary

Switches the release publish job to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), matching the trusted publisher configuration set up on npmjs.com.

### Workflow changes (`release-please.yml`)

- **`id-token: write`** permission on the publish job (job-level, least privilege — the release-please job keeps its existing permissions) so GitHub Actions can mint the OIDC token.
- **`registry-url: 'https://registry.npmjs.org'`** in `setup-node`, and the yarn cache removed from the publish job per npm's release-build guidance.
- **npm upgraded to latest** before publishing — trusted publishing requires npm ≥ 11.5.1, while Node 22 still bundles npm 10.
- **Publish via the npm CLI** (`npm publish --access public` from `packages/sentry-testkit`) instead of `yarn npm publish` — Yarn's publish flow doesn't support OIDC, so it would fall back to looking for a token.
- **`NPM_TOKEN` removed** from the workflow entirely.

### Related project changes

- `package.json` `repository.url` normalized from `git@github.com:...` to `git+https://github.com/zivl/sentry-testkit.git` — provenance validation requires it to exactly match the GitHub repository.
- `CONTRIBUTING.md` release section documents the OIDC flow, automatic provenance, and the gotcha that the trusted publisher config is tied to the `release-please.yml` filename.

## Verification

- Workflow YAML parses cleanly.
- `npm pack --dry-run` from `packages/sentry-testkit` packs the expected contents (dist + package.json, 42 files).
- Real proof comes with the next release-please release — worth watching the publish job on the first release after this merges.

## Follow-up (repo settings, not in this PR)

Once this is merged and the first OIDC publish succeeds, the `NPM_TOKEN` repository secret can be deleted — nothing references it anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)