### PR TITLE
fix(ci): publish through the npm_deploy environment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    # Must match the environment configured in the npm trusted publisher
+    # settings for this package, or the OIDC token exchange is rejected
+    environment: npm_deploy
     permissions:
       contents: read
       # Required for npm trusted publishing (OIDC):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Release process:
 - once the Release PR is merged, release-please creates a GitHub release and a git tag;
 - the CI workflow then builds, tests, and publishes the package to npm automatically.
 
-Publishing uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC): the workflow authenticates via a short-lived token issued to the `release-please.yml` workflow — no `NPM_TOKEN` secret is involved — and npm generates provenance attestations for every release. The trusted publisher configuration lives on npmjs.com (package settings → Trusted Publisher) and is tied to this repository and workflow filename, so renaming `release-please.yml` requires updating that configuration too.
+Publishing uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC): the workflow authenticates via a short-lived token issued to the `release-please.yml` workflow — no `NPM_TOKEN` secret is involved — and npm generates provenance attestations for every release. The trusted publisher configuration lives on npmjs.com (package settings → Trusted Publisher) and is tied to this repository, the workflow filename, and the `npm_deploy` GitHub environment — renaming `release-please.yml`, changing the publish job's `environment`, or renaming the environment requires updating that configuration too, or the OIDC token exchange is silently rejected and the publish fails with a misleading `E404`.
 
 No manual steps are required. The version bump is determined by the commit types on `master`:
 


### PR DESCRIPTION
## Summary

The v7.0.1 npm publish failed with `E404` ([run log](https://github.com/zivl/sentry-testkit/actions/runs/29490878972/job/87596488410)). Diagnosis:

- The workflow's `id-token: write` works — verified the OIDC env is injected via a throwaway debug workflow.
- The npm trusted publisher config for this package specifies the **`npm_deploy` environment**, but the publish job didn't declare one, so the OIDC claims didn't match. npm silently fell back to setup-node's placeholder token, and the registry rejected the publish as an unauthenticated `E404`.

Fix: declare `environment: npm_deploy` on the publish job, and document the coupling in CONTRIBUTING.md (repo + workflow filename + environment must all match the npmjs.com config exactly).

Merging this as a `fix:` makes release-please cut **v7.0.2**, which will be the first version actually published via trusted publishing — v7.0.1 remains a git-tag-only release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)