### PR TITLE
docs(readme): ship a package README to npm and refresh the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,32 @@
     </a>
 </p>
 
-Sentry is an open-source JavaScript SDK published by [Sentry](https://sentry.io/welcome/) to enable error tracking that helps developers monitor and fix crashes in real time.<br>
-However, when building tests for your application, you want to assert that the right flow-tracking or error is being sent to _Sentry_, **but** without really sending it to _Sentry_ servers. This way you won't swamp Sentry with false reports during test running and other CI operations.
+Test what your app reports to [Sentry](https://sentry.io/welcome/) — without sending anything to Sentry's servers.
 
-## Sentry Testkit - to the rescue
+When building tests for your application you want to assert that the right flow-tracking or error is being sent to _Sentry_, **but** without really sending it and swamping your Sentry project with false reports from test runs and CI.
 
-_Sentry Testkit_ enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
+## Sentry Testkit — to the rescue
+
+_Sentry Testkit_ enables Sentry to work natively in your application while running tests: reports are intercepted and logged into memory instead of being sent over the wire. Your tests can then fetch and assert on everything that was (or wasn't) captured:
+
+- **Errors and messages** — `captureException`, `captureMessage`, breadcrumbs, tags, extra, user
+- **Performance transactions and spans** — names, ops, attributes, span trees
+- **Structured logs** — everything sent via `Sentry.logger.*`
+- **Feature flags** — which flags were evaluated when an error was captured
+- **Async-safe assertions** — built-in `waitFor*` helpers, no sleeps and no flaky tests
 
 ## Installation
 
 **npm:**
-```
+```sh
 npm install sentry-testkit --save-dev
 ```
 **yarn:**
-```
+```sh
 yarn add sentry-testkit --dev
 ```
+
+Requires Sentry JavaScript SDK **v9 or v10**. Using Sentry v8? Stay on `sentry-testkit@6` or see the [v7 migration guide](https://zivl.github.io/sentry-testkit/docs/migration/version-7).
 
 ## Usage
 
@@ -47,36 +56,61 @@ yarn add sentry-testkit --dev
 // some.spec.js
 const sentryTestkit = require('sentry-testkit')
 
-const {testkit, sentryTransport} = sentryTestkit()
+const { testkit, sentryTransport } = sentryTestkit()
 
 // initialize your Sentry instance with sentryTransport
 Sentry.init({
     dsn: 'some_dummy_dsn',
     transport: sentryTransport,
+    enableLogs: true, // if you want to test Sentry.logger.* calls
     //... other configurations
 })
 
-test('collect error events', function () {
+test('collects error events', async function () {
   // run any scenario that eventually calls Sentry.captureException(...)
-  expect(testkit.reports()).toHaveLength(1)
-  const report = testkit.reports()[0]
-  expect(report).toHaveProperty(...)
-});
+  const reports = await testkit.waitForReports(1)
+  expect(reports[0].error.message).toEqual('something went wrong')
+})
 
-// Similarly for performance events
-test('collect performance events', function () {
-  // run any scenario that eventually calls Sentry.startTransaction(...)
-  expect(testkit.transactions()).toHaveLength(1)
-});
+test('collects performance events', async function () {
+  // run any scenario that eventually starts and ends a span
+  await testkit.waitForTransactions(1)
+  expect(testkit.findTransaction('checkout-flow')).toBeDefined()
+})
+
+test('collects structured logs', async function () {
+  Sentry.logger.info('user logged in', { userId: 42 })
+  await Sentry.flush()
+  expect(testkit.logs()[0].attributes.userId).toEqual(42)
+})
 ```
 
-## Testkit API
+More querying power when you need it:
 
-See full API description and documentation here: https://zivl.github.io/sentry-testkit/
+```javascript
+testkit.findReportByMessage(/user \d+/)
+testkit.reportsWithTag('section', 'billing')
+testkit.transactionsWithTag('flow', 'signup')
+testkit.reports()[0].flags // [{ flag: 'new-checkout', result: true }]
+testkit.reset()            // clean state between tests
+```
 
-## Running in browser
+## Integration modes
 
-`sentry-testkit` relies on `express` and `http` packages from NodeJS. We have separated entry `sentry-testkit/browser` where we not include any NodeJS-related code.
+The custom transport shown above is the most common setup, but the testkit can intercept Sentry traffic in whichever way fits your test environment:
+
+| Mode | Use case |
+|------|----------|
+| **Transport** (`sentryTransport`) | Unit/integration tests — replaces Sentry's HTTP sender |
+| **Browser entry** (`sentry-testkit/browser`) | Same as transport, without any Node.js dependencies |
+| **Local server** (`localServer`) | A real local endpoint that mimics Sentry's API and generates a local DSN |
+| **Puppeteer** (`testkit.puppeteer`) | E2E tests — captures the page's Sentry requests |
+| **Network interception** (`initNetworkInterceptor`) | Bring your own interceptor (nock, MSW, ...) |
+| **Jest mock** (`sentry-testkit/dist/jestMock`) | Auto-injects the testkit as `global.testkit` |
+
+### Running in browser
+
+`sentry-testkit` relies on `express` and `http` packages from NodeJS. We have a separate entry `sentry-testkit/browser` which does not include any NodeJS-related code:
 
 ```javascript
 const sentryTestkit = require('sentry-testkit/browser')
@@ -85,14 +119,25 @@ const { testkit } = sentryTestkit()
 // Your code for browser
 ```
 
+## Testkit API
+
+See the full API description and documentation here: https://zivl.github.io/sentry-testkit/
+
+## Roadmap
+
+sentry-testkit is expanding to cover the full modern Sentry SDK surface — user feedback, cron check-ins, sessions, session replay, attachments, metrics, and more. Follow (or help shape) the plan in the [tracking issue](https://github.com/zivl/sentry-testkit/issues/313).
+
 ## Raven-Testkit
-The good old legacy `raven-testkit` documentation can be found [here](LEGACY_API.md). It it still there to serve `Raven` which is the old legacy SDK of _Sentry_ for JavaScript/Node.js platforms
+
+The good old legacy `raven-testkit` documentation can be found [here](LEGACY_API.md). It is still there to serve `Raven`, which is the old legacy SDK of _Sentry_ for JavaScript/Node.js platforms.
 
 ## Change Log
-We're constantly and automatically updating our [CHANGELOG](./CHANGELOG.md) file, so its always a good spot to checkout what have we been up to...
+
+We're constantly and automatically updating our [CHANGELOG](./packages/sentry-testkit/CHANGELOG.md) file, so it's always a good spot to check out what we have been up to...
 
 ## Contribution
-We'd love any kind of contribution, to get better, improve our capabilities, fix bugs and bring more features as Sentry expanding their tools as well. Please check our [CONTRIBUTING](./CONTRIBUTING.md) guidelines for more info and how to get started.
+
+We'd love any kind of contribution to get better, improve our capabilities, fix bugs, and bring more features as Sentry expands their tools as well. Please check our [CONTRIBUTING](./CONTRIBUTING.md) guidelines for more info and how to get started.
 
 ## License
 

--- a/packages/sentry-testkit/README.md
+++ b/packages/sentry-testkit/README.md
@@ -1,0 +1,121 @@
+<p align="center">
+<a href="https://npmjs.org/package/sentry-testkit">
+    <img src="https://img.shields.io/npm/v/sentry-testkit.svg" alt="npm version">
+  </a>
+<a href="https://npmjs.org/package/sentry-testkit">
+    <img src="https://img.shields.io/npm/dm/sentry-testkit.svg" alt="npm downloads">
+  </a>
+<a href="https://github.com/zivl/sentry-testkit/actions">
+    <img src="https://github.com/zivl/sentry-testkit/workflows/Test/badge.svg" alt="Test">
+  </a>
+<a href="https://zivl.github.io/sentry-testkit/">
+    <img src="https://img.shields.io/badge/Compatible%20with%20Sentry-v9%20%7C%20v10-blue" alt="compatible with Sentry v9 and v10">
+  </a>
+</p>
+
+# sentry-testkit
+
+Test what your app reports to [Sentry](https://sentry.io) — without sending anything to Sentry's servers.
+
+**sentry-testkit** lets Sentry work natively in your application while running tests: reports are intercepted and logged into memory instead of being sent over the wire. Your tests can then assert on exactly what was (or wasn't) captured — errors, performance transactions, structured logs, and more — with nothing leaving your machine and no false reports swamping your Sentry project.
+
+## Installation
+
+```sh
+npm install sentry-testkit --save-dev
+# or
+yarn add sentry-testkit --dev
+```
+
+Requires Sentry JavaScript SDK **v9 or v10** (`@sentry/browser`, `@sentry/node`, `@sentry/react`, `@sentry/react-native`). Using Sentry v8? Stay on `sentry-testkit@6`.
+
+## Quick start
+
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const { testkit, sentryTransport } = sentryTestkit()
+
+// initialize Sentry with the testkit transport
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/000001',
+  transport: sentryTransport,
+  // ... other configurations
+})
+
+test('collects error events', async function() {
+  // run any scenario that eventually calls Sentry.captureException(...)
+  const reports = await testkit.waitForReports(1)
+  expect(reports[0].error.message).toEqual('something went wrong')
+})
+```
+
+## What you can assert on
+
+```javascript
+// Errors and messages
+testkit.reports()
+testkit.findReport(error)
+testkit.findReportByMessage(/user \d+/)
+testkit.reportsWithTag('section', 'billing')
+testkit.getExceptionAt(0)
+
+// Performance transactions and spans
+testkit.transactions()
+testkit.findTransaction('checkout-flow')
+testkit.transactionsWithTag('flow', 'signup')
+
+// Structured logs (Sentry.logger.*, requires enableLogs: true)
+testkit.logs()
+
+// Feature flags evaluated when an error was captured
+testkit.reports()[0].flags // [{ flag: 'new-checkout', result: true }]
+
+// Async-safe waiting — no sleeps, no flakiness
+await testkit.waitForReports(2, { timeout: 3000 })
+await testkit.waitForTransactions(1)
+await testkit.waitForLogs(1)
+
+// Clean state between tests
+testkit.reset()
+```
+
+See the [full API reference](https://zivl.github.io/sentry-testkit/docs/api) for every method and the shape of `Report`, `Transaction`, and `Log` objects.
+
+## Integration modes
+
+The transport shown above is the most common setup, but the testkit can intercept Sentry traffic in whichever way fits your test environment:
+
+| Mode | Use case |
+|------|----------|
+| **Transport** (`sentryTransport`) | Unit/integration tests — replace Sentry's HTTP sender |
+| **Browser entry** (`sentry-testkit/browser`) | Same as transport, without any Node.js dependencies |
+| **Local server** (`localServer`) | Spin up a real local endpoint that mimics Sentry's API and gives you a local DSN |
+| **Puppeteer** (`testkit.puppeteer`) | E2E tests — capture the page's Sentry requests |
+| **Network interception** (`initNetworkInterceptor`) | Bring your own interceptor (nock, MSW, ...) |
+| **Jest mock** (`sentry-testkit/dist/jestMock`) | Auto-inject the testkit as `global.testkit` |
+
+```javascript
+// browser-only entry, no express/http imports
+const sentryTestkit = require('sentry-testkit/browser')
+const { testkit, sentryTransport } = sentryTestkit()
+```
+
+Guides for every mode live in the [documentation](https://zivl.github.io/sentry-testkit/).
+
+## Documentation
+
+Full documentation, guides, and migration notes: **https://zivl.github.io/sentry-testkit/**
+
+- [Getting started](https://zivl.github.io/sentry-testkit/docs/getting-started)
+- [API reference](https://zivl.github.io/sentry-testkit/docs/api)
+- [Migration guides](https://zivl.github.io/sentry-testkit/docs/migration/version-7) (v7 drops Sentry v8 support and adds structured logs)
+- [Changelog](https://github.com/zivl/sentry-testkit/blob/master/packages/sentry-testkit/CHANGELOG.md)
+
+## Contributing
+
+Contributions of any kind are welcome! See the [contribution guidelines](https://github.com/zivl/sentry-testkit/blob/master/CONTRIBUTING.md) to get started.
+
+## License
+
+[MIT](https://github.com/zivl/sentry-testkit/blob/master/LICENSE)


### PR DESCRIPTION
## Summary

Two README updates:

### New: packages/sentry-testkit/README.md (ships to npm)

The published npm package has no README (the files allowlist only ever shipped built code), so the npmjs.com page is empty. npm includes a package-level README.md automatically regardless of the files allowlist — verified with npm pack --dry-run (README.md, 4.8kB, now in the tarball, 43 files total).

Written for the npm page: pitch and badges, install, quick start using waitForReports, an API tour (reports, transactions, logs, flags, query/waitFor helpers), the integration-modes table, and absolute URLs everywhere since relative repo links break on npmjs.com. Includes the Sentry v9/v10 compatibility note with a pointer to sentry-testkit@6 for v8 users.

### Refreshed: root README.md (GitHub)

Brought up to date with v7: feature bullets (errors, transactions, logs, flags, waitFor helpers), async-safe quick-start examples replacing the sync ones, a "more querying power" snippet, the integration-modes table, compatibility note and v7 migration guide link, a roadmap section pointing to tracking issue #313, and the changelog link fixed to its actual location (packages/sentry-testkit/CHANGELOG.md). Badges, logo, and overall structure preserved.

Typed as fix: so release-please cuts a patch release and the package README actually ships to npm.

Generated with [Claude Code](https://claude.com/claude-code)