### PR TITLE
feat(playwright): add Playwright integration via testkit.playwright

### DIFF
--- a/packages/sentry-testkit-docs/docs/getting-started.md
+++ b/packages/sentry-testkit-docs/docs/getting-started.md
@@ -70,6 +70,30 @@ testkit.puppeteer.startListening(page, 'https://my-self-hosted-sentry.com');
 ```
 :::
 
+### Using with [Playwright](https://playwright.dev/)
+The Playwright integration mirrors the Puppeteer one — pass a Playwright `Page` and the testkit captures every Sentry request the page makes:
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const {testkit} = sentryTestkit()
+
+testkit.playwright.startListening(page);
+
+// Run any scenario that will call Sentry.captureException(...), for example:
+await page.addScriptTag({ content: `throw new Error('An error');` });
+
+expect(testkit.reports()).toHaveLength(1)
+
+testkit.playwright.stopListening(page);
+```
+
+:::info
+As with Puppeteer, `startListening` accepts an optional `baseUrl` second parameter (defaults to 'https://sentry.io') for self-hosted Sentry:
+```javascript
+testkit.playwright.startListening(page, 'https://my-self-hosted-sentry.com');
+```
+:::
+
 ### Reset between tests
 As you might run more than one test with *Sentry* and *Sentry-Testkit*, you might want to use the `reset` function in between tests.
 Usually, your testing framework will have a hook for that kind of action. In the following example, We're using [Jest](https://jestjs.io/docs/en/api.html)'s hooks: `beforeEach`, `beforeAll`

--- a/packages/sentry-testkit/__tests__/playwright.test.ts
+++ b/packages/sentry-testkit/__tests__/playwright.test.ts
@@ -1,0 +1,98 @@
+import EventEmitter from 'events'
+import sentryTestkit from '../src/index'
+
+const { testkit } = sentryTestkit()
+
+describe('Playwright testkit', () => {
+  let page: EventEmitter
+  const errorMessage = 'sentry playwright testkit is awesome!'
+  const createSentryCaptureRequest = (baseUrl = 'https://sentry.io') => ({
+    url: () => `${baseUrl}/api/1234567/store`,
+    postData: () =>
+      JSON.stringify({
+        exception: {
+          values: [{ value: errorMessage }],
+        },
+      }),
+  })
+  const createSentryPerfRequest = (baseUrl = 'https://sentry.io') => ({
+    url: () => `${baseUrl}/api/1234567/envelope`,
+    postData: () =>
+      `{"event_id":"601fdd0eb40343f08274857951e483de","sent_at":"2021-06-11T16:57:39.943Z","sdk":{"name":"sentry.javascript.node","version":"6.6.0"}}
+      {"type":"transaction","sample_rates":[{"id":"client_rate","rate":1}]}
+      {"contexts":{"trace":{"op":"transaction","span_id":"9ce5f4be9f39417f","trace_id":"57909d703068487a9e3cff52a6279484"}},"spans":[],"tags":{},"transaction":"transaction-name","type":"transaction","platform":"node","event_id":"601fdd0eb40343f08274857951e483de"}`,
+  })
+  const sentryLogsRequest = {
+    url: () => 'https://sentry.io/api/1234567/envelope',
+    postData: () => `{"sent_at":"2026-07-18T14:27:12.489Z","sdk":{"name":"sentry.javascript.node","version":"10.0.0"}}
+{"type":"log","item_count":1,"content_type":"application/vnd.sentry.items.log+json"}
+{"items":[{"timestamp":1717081538.235,"level":"info","body":"user logged in","attributes":{"userId":{"value":42,"type":"integer"}}}]}`,
+  }
+  const sentrySessionRequest = {
+    url: () => 'https://sentry.io/api/1234567/envelope',
+    postData: () => `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.react","version":"6.11.0"}}
+{"type":"session"}
+{"sid":"<removed>","init":false,"started":"2021-08-17T14:27:11.361Z","timestamp":"2021-08-17T14:27:12.489Z","status":"ok","errors":1,"attrs":{"release":"<removed>","environment":"<removed>","user_agent":"<removed>"}}`,
+  }
+
+  beforeEach(() => {
+    testkit.reset()
+    page = new EventEmitter()
+  })
+
+  test('should report to testkit', () => {
+    testkit.playwright.startListening(page)
+    page.emit('request', createSentryCaptureRequest())
+    expect(testkit.reports()).toHaveLength(1)
+    const { message } = testkit.getExceptionAt(0)!
+    expect(message).toEqual(errorMessage)
+  })
+
+  test('should collect performance transactions', () => {
+    testkit.playwright.startListening(page)
+    page.emit('request', createSentryPerfRequest())
+    expect(testkit.transactions()).toHaveLength(1)
+    expect(testkit.transactions()[0]!.name).toEqual('transaction-name')
+  })
+
+  test('should collect structured logs', () => {
+    testkit.playwright.startListening(page)
+    page.emit('request', sentryLogsRequest)
+    expect(testkit.logs()).toHaveLength(1)
+    expect(testkit.logs()[0]!.message).toEqual('user logged in')
+    expect(testkit.logs()[0]!.attributes['userId']).toEqual(42)
+  })
+
+  test('should handle session items in an envelope request', () => {
+    testkit.playwright.startListening(page)
+    page.emit('request', sentrySessionRequest)
+    expect(testkit.transactions()).toHaveLength(0)
+  })
+
+  test('should stop listening after calling stopListening', () => {
+    testkit.playwright.startListening(page)
+    testkit.playwright.stopListening(page)
+    page.emit('request', createSentryCaptureRequest())
+    expect(testkit.reports()).toHaveLength(0)
+  })
+
+  test('should not interfere with an active puppeteer listener', () => {
+    const puppeteerPage = new EventEmitter()
+    testkit.puppeteer.startListening(puppeteerPage)
+    testkit.playwright.startListening(page)
+    testkit.playwright.stopListening(page)
+
+    page.emit('request', createSentryCaptureRequest())
+    puppeteerPage.emit('request', createSentryCaptureRequest())
+
+    expect(testkit.reports()).toHaveLength(1)
+    testkit.puppeteer.stopListening(puppeteerPage)
+  })
+
+  test('should support self-hosted sentry', () => {
+    const baseUrl = 'https://my-self-hosted-sentry.com'
+    testkit.playwright.startListening(page, baseUrl)
+    page.emit('request', createSentryCaptureRequest(baseUrl))
+    expect(testkit.reports()).toHaveLength(1)
+  })
+})

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -47,8 +47,7 @@ export function createTestkit(): Testkit {
   let transactions: Transaction[] = []
   let logs: Log[] = []
 
-  let puppeteerHandler: any = null
-  const createPuppeteerHandler = (baseUrl: string) => (request: any) => {
+  const createRequestHandler = (baseUrl: string) => (request: any) => {
     const url = request.url()
     if (!url.startsWith(baseUrl)) {
       return
@@ -71,17 +70,25 @@ export function createTestkit(): Testkit {
     }
   }
 
-  return {
-    puppeteer: {
+  // Puppeteer and Playwright expose the same request surface:
+  // page.on/off('request') with request.url() and request.postData()
+  const createPageListener = () => {
+    let handler: any = null
+    return {
       startListening: (page: any, baseUrl: string = 'https://sentry.io') => {
-        puppeteerHandler = createPuppeteerHandler(baseUrl)
-        page.on('request', puppeteerHandler)
+        handler = createRequestHandler(baseUrl)
+        page.on('request', handler)
       },
 
       stopListening: (page: any) => {
-        page.off('request', puppeteerHandler)
+        page.off('request', handler)
       },
-    },
+    }
+  }
+
+  return {
+    puppeteer: createPageListener(),
+    playwright: createPageListener(),
 
     reports() {
       return reports

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -90,6 +90,10 @@ declare namespace sentryTestkit {
       startListening(page: Page, baseUrl?: string): void
       stopListening(page: Page): void
     }
+    playwright: {
+      startListening(page: Page, baseUrl?: string): void
+      stopListening(page: Page): void
+    }
     reports(): Report[]
     transactions(): Transaction[]
     logs(): Log[]


### PR DESCRIPTION
## Summary

Implements #312: a first-class Playwright integration mirroring the existing Puppeteer one.

```javascript
testkit.playwright.startListening(page)          // or (page, 'https://my-self-hosted-sentry.com')
// ... run the page scenario ...
expect(testkit.reports()).toHaveLength(1)
testkit.playwright.stopListening(page)
```

Design notes:

- Playwright pages expose the same request surface Puppeteer does (`page.on/off('request')`, `request.url()`, `request.postData()`), so the existing Puppeteer handler was extracted into a shared page-listener factory used by both `testkit.puppeteer` and `testkit.playwright`. Each namespace keeps independent handler state, so both can listen simultaneously without interfering.
- The shared handler routes all supported envelope item types, so Playwright capture includes events, transactions, and structured logs from day one.
- No new dependency: like the Puppeteer integration, nothing is imported from Playwright at runtime — the page object is provided by the caller.

## Test plan

- New `__tests__/playwright.test.ts` mirroring the Puppeteer suite: error capture, transactions, structured logs, session-item tolerance, `stopListening`, no cross-talk with an active Puppeteer listener, and self-hosted `baseUrl`.
- Full suite: 12 suites, 181 tests green (`yarn build`, `yarn test`).
- Docs: "Using with Playwright" section added to Getting Started; `yarn workspace sentry-testkit-docs build` passes with no new broken links.

Closes #312