### PR TITLE
feat: capture user feedback and cron check-ins

### DIFF
--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -244,6 +244,60 @@ test('logs example', async function() {
 })
 ```
 
+### `feedback()`
+Gets all captured [user feedback](https://docs.sentry.io/platforms/javascript/user-feedback/) submitted via `Sentry.captureFeedback(...)` or the feedback widget.
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>FeedbackReport</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | <code>string</code> | The feedback message |
+| `name` | <code>string</code> | The submitter's name, if provided |
+| `contactEmail` | <code>string</code> | The submitter's email, if provided |
+| `url` | <code>string</code> | The page the feedback was submitted from, if provided |
+| `associatedEventId` | <code>string</code> | The id of the error event this feedback is linked to, if any |
+| `source` | <code>string</code> | The feedback source, if provided |
+| `replayId` | <code>string</code> | The associated replay id, if any |
+| `eventId` | <code>string</code> | The feedback event's own id |
+| `originalFeedback` | <code>Object</code> | The raw feedback event as sent by the SDK |
+
+For example
+```javascript
+test('feedback example', async function() {
+    Sentry.captureFeedback({ message: 'the checkout page is confusing', email: 'jane@example.com' })
+
+    const [feedback] = await testkit.waitForFeedback(1)
+    expect(feedback.message).toEqual('the checkout page is confusing')
+    expect(feedback.contactEmail).toEqual('jane@example.com')
+})
+```
+
+### `checkIns()`
+Gets all captured [cron monitor check-ins](https://docs.sentry.io/platforms/javascript/crons/) reported via `Sentry.captureCheckIn(...)` or `Sentry.withMonitor(...)`.
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>CheckIn</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `checkInId` | <code>string</code> | The check-in id (used to correlate an `in_progress` with its `ok`/`error`) |
+| `monitorSlug` | <code>string</code> | The monitor's slug |
+| `status` | <code>string</code> | `in_progress` \| `ok` \| `error` |
+| `duration` | <code>number</code> | The check-in duration in seconds, for a finished check-in |
+| `release` | <code>string</code> | The release, if set |
+| `environment` | <code>string</code> | The environment, if set |
+| `originalCheckIn` | <code>Object</code> | The raw check-in payload as sent by the SDK |
+
+For example
+```javascript
+test('check-in example', async function() {
+    const checkInId = Sentry.captureCheckIn({ monitorSlug: 'nightly-report', status: 'in_progress' })
+    Sentry.captureCheckIn({ checkInId, monitorSlug: 'nightly-report', status: 'ok', duration: 12.5 })
+
+    const checkIns = await testkit.waitForCheckIns(2)
+    expect(checkIns.map(c => c.status)).toEqual(['in_progress', 'ok'])
+})
+```
+
 ### `reset()`
 Resets the testkit state and clear all existing reports.
 

--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -8,11 +8,26 @@ sidebar_position: 2
 Sentry Testkit consists of a very simple and strait-forward API using the following functions
 
 ## Methods
-* [`reports()`](#reports)
+
+**Capture and assertions**
+* [`reports()`](#reports) — captured errors and messages
+* [`transactions()`](#transactions) — captured performance transactions
+* [`logs()`](#logs) — captured structured logs
+* [`feedback()`](#feedback) — captured user feedback
+* [`checkIns()`](#checkins) — captured cron monitor check-ins
+
+**Awaiting asynchronously-sent data**
+* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForFeedback`, `waitForCheckIns`
+
+**Finding and filtering**
 * [`findReport(error)`](#findreporterror)
+* [`findReportByMessage(message)`](#findreportbymessagemessage)
+* [`findTransaction(name)`](#findtransactionname)
+* [`reportsWithTag(key, value)`](#reportswithtagkey-value) — and `transactionsWithTag(key, value)`
 * [`isExist(error)`](#isexisterror)
 * [`getExceptionAt(index)`](#getexceptionatindex)
-* [`transactions()`](#transactions)
+
+**Utilities**
 * [`reset()`](#reset)
 
 ### What About Nodejs? - Of Course!

--- a/packages/sentry-testkit-docs/docs/getting-started.md
+++ b/packages/sentry-testkit-docs/docs/getting-started.md
@@ -44,55 +44,27 @@ test('collect performance events', function () {
 });
 ```
 
-### Using with [Puppeteer](https://pptr.dev/)
+### Beyond errors: logs, feedback and check-ins
+
+`sentry-testkit` captures more than errors and transactions. If your app uses these Sentry features, you can assert on them the same way — each has its own accessor and an awaitable `waitFor*` helper:
+
+- **[Structured logs](/docs/api#logs)** — everything sent via `Sentry.logger.*` (requires `enableLogs: true` in `Sentry.init`), via `testkit.logs()`
+- **[User feedback](/docs/api#feedback)** — submissions from `Sentry.captureFeedback(...)` or the feedback widget, via `testkit.feedback()`
+- **[Cron check-ins](/docs/api#checkins)** — monitor check-ins from `Sentry.captureCheckIn(...)` / `Sentry.withMonitor(...)`, via `testkit.checkIns()`
+
 ```javascript
-const sentryTestkit = require('sentry-testkit')
+Sentry.captureFeedback({ message: 'the checkout page is confusing' })
 
-const {testkit} = sentryTestkit()
-
-testkit.puppeteer.startListening(page);
-
-// Run any scenario that will call Sentry.captureException(...), for example:
-await page.addScriptTag({ content: `throw new Error('An error');` });
-
-expect(testkit.reports()).toHaveLength(1)
-
-const report = testkit.reports()[0]
-expect(report).toHaveProperty(...)
-
-testkit.puppeteer.stopListening(page);
+const [feedback] = await testkit.waitForFeedback(1)
+expect(feedback.message).toEqual('the checkout page is confusing')
 ```
 
-:::info
-`startListening` has an optional `baseUrl` as second parameter (it defaults to 'https://sentry.io'), so you can pass the URL of your server:
-```javascript
-testkit.puppeteer.startListening(page, 'https://my-self-hosted-sentry.com');
-```
-:::
+### End-to-end testing (Puppeteer & Playwright)
 
-### Using with [Playwright](https://playwright.dev/)
-The Playwright integration mirrors the Puppeteer one — pass a Playwright `Page` and the testkit captures every Sentry request the page makes:
-```javascript
-const sentryTestkit = require('sentry-testkit')
+For browser end-to-end tests, `sentry-testkit` can capture the Sentry requests a page makes — no change to your application's `Sentry.init` is required. See the dedicated guides:
 
-const {testkit} = sentryTestkit()
-
-testkit.playwright.startListening(page);
-
-// Run any scenario that will call Sentry.captureException(...), for example:
-await page.addScriptTag({ content: `throw new Error('An error');` });
-
-expect(testkit.reports()).toHaveLength(1)
-
-testkit.playwright.stopListening(page);
-```
-
-:::info
-As with Puppeteer, `startListening` accepts an optional `baseUrl` second parameter (defaults to 'https://sentry.io') for self-hosted Sentry:
-```javascript
-testkit.playwright.startListening(page, 'https://my-self-hosted-sentry.com');
-```
-:::
+- [Using with Puppeteer](/docs/puppeteer)
+- [Using with Playwright](/docs/playwright)
 
 ### Reset between tests
 As you might run more than one test with *Sentry* and *Sentry-Testkit*, you might want to use the `reset` function in between tests.

--- a/packages/sentry-testkit-docs/docs/playwright.md
+++ b/packages/sentry-testkit-docs/docs/playwright.md
@@ -1,0 +1,36 @@
+---
+title: Playwright
+description: Capture Sentry requests from a Playwright page with Sentry Testkit
+sidebar_position: 7
+---
+
+# Using with [Playwright](https://playwright.dev/)
+
+The Playwright integration mirrors the [Puppeteer](/docs/puppeteer) one. Pass a Playwright `Page` to `testkit.playwright.startListening(page)` and the testkit captures everything the page sends to Sentry — reports, transactions, logs, feedback, and check-ins — with no change to your application's `Sentry.init`.
+
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const { testkit } = sentryTestkit()
+
+testkit.playwright.startListening(page)
+
+// Run any scenario that will call Sentry.captureException(...), for example:
+await page.addScriptTag({ content: `throw new Error('An error');` })
+
+expect(testkit.reports()).toHaveLength(1)
+
+testkit.playwright.stopListening(page)
+```
+
+## Self-hosted Sentry
+
+As with Puppeteer, `startListening` accepts an optional `baseUrl` as a second parameter (it defaults to `https://sentry.io`) for self-hosted Sentry:
+
+```javascript
+testkit.playwright.startListening(page, 'https://my-self-hosted-sentry.com')
+```
+
+:::tip
+Sentry sends events asynchronously. Prefer the awaitable [`waitForReports`](/docs/api#waitforreportscount-options) helper (and its siblings `waitForTransactions`, `waitForLogs`, `waitForFeedback`, `waitForCheckIns`) over asserting immediately after triggering the scenario.
+:::

--- a/packages/sentry-testkit-docs/docs/puppeteer.md
+++ b/packages/sentry-testkit-docs/docs/puppeteer.md
@@ -1,0 +1,44 @@
+---
+title: Puppeteer
+description: Capture Sentry requests from a Puppeteer page with Sentry Testkit
+sidebar_position: 6
+---
+
+# Using with [Puppeteer](https://pptr.dev/)
+
+When testing a real browser with [Puppeteer](https://pptr.dev/), `sentry-testkit` can intercept the Sentry requests the page makes — no change to your application's `Sentry.init` is required.
+
+Pass the Puppeteer `page` to `testkit.puppeteer.startListening(page)` and the testkit captures everything the page sends to Sentry — reports, transactions, logs, feedback, and check-ins — so you can assert on it with the usual API.
+
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const { testkit } = sentryTestkit()
+
+testkit.puppeteer.startListening(page)
+
+// Run any scenario that will call Sentry.captureException(...), for example:
+await page.addScriptTag({ content: `throw new Error('An error');` })
+
+expect(testkit.reports()).toHaveLength(1)
+const report = testkit.reports()[0]
+expect(report).toHaveProperty(...)
+
+testkit.puppeteer.stopListening(page)
+```
+
+## Self-hosted Sentry
+
+`startListening` accepts an optional `baseUrl` as a second parameter (it defaults to `https://sentry.io`), so you can point it at your own server:
+
+```javascript
+testkit.puppeteer.startListening(page, 'https://my-self-hosted-sentry.com')
+```
+
+:::tip
+Sentry sends events asynchronously. Prefer the awaitable [`waitForReports`](/docs/api#waitforreportscount-options) helper (and its siblings `waitForTransactions`, `waitForLogs`, `waitForFeedback`, `waitForCheckIns`) over asserting immediately after triggering the scenario.
+:::
+
+:::info
+Prefer Playwright? See the [Playwright guide](/docs/playwright) — the integration is identical.
+:::

--- a/packages/sentry-testkit/__tests__/checkins.test.ts
+++ b/packages/sentry-testkit/__tests__/checkins.test.ts
@@ -1,0 +1,79 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+describe('sentry test-kit test suite - cron check-ins', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      environment: 'ci',
+      transport: sentryTransport,
+    })
+  )
+
+  beforeEach(() => testkit.reset())
+
+  test('checkIns() is empty when nothing was reported', () => {
+    expect(testkit.checkIns()).toEqual([])
+  })
+
+  test('captures an in-progress check-in with its monitor slug', async () => {
+    Sentry.captureCheckIn({
+      monitorSlug: 'nightly-report',
+      status: 'in_progress',
+    })
+    const [checkIn] = await testkit.waitForCheckIns(1)
+
+    expect(checkIn!.monitorSlug).toBe('nightly-report')
+    expect(checkIn!.status).toBe('in_progress')
+    expect(checkIn!.checkInId).toEqual(expect.any(String))
+    expect(checkIn!.release).toBe('test')
+    expect(checkIn!.environment).toBe('ci')
+  })
+
+  test('captures a finished check-in with its status and duration', async () => {
+    const checkInId = Sentry.captureCheckIn({
+      monitorSlug: 'nightly-report',
+      status: 'in_progress',
+    })
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'nightly-report',
+      status: 'ok',
+      duration: 12.5,
+    })
+    const checkIns = await testkit.waitForCheckIns(2)
+
+    expect(checkIns.map(c => c.status)).toEqual(['in_progress', 'ok'])
+    const finished = checkIns[1]!
+    expect(finished.checkInId).toBe(checkInId)
+    expect(finished.duration).toBe(12.5)
+  })
+
+  test('captures a failed check-in', async () => {
+    Sentry.captureCheckIn({ monitorSlug: 'nightly-report', status: 'error' })
+    const [checkIn] = await testkit.waitForCheckIns(1)
+
+    expect(checkIn!.status).toBe('error')
+  })
+
+  test('exposes the raw check-in payload as originalCheckIn', async () => {
+    Sentry.captureCheckIn({ monitorSlug: 'raw-monitor', status: 'ok' })
+    const [checkIn] = await testkit.waitForCheckIns(1)
+
+    expect(checkIn!.originalCheckIn.monitor_slug).toBe('raw-monitor')
+    expect(checkIn!.originalCheckIn.status).toBe('ok')
+  })
+
+  test('reset() clears captured check-ins', async () => {
+    Sentry.captureCheckIn({ monitorSlug: 'nightly-report', status: 'ok' })
+    await testkit.waitForCheckIns(1)
+
+    testkit.reset()
+
+    expect(testkit.checkIns()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/__tests__/feedback.test.ts
+++ b/packages/sentry-testkit/__tests__/feedback.test.ts
@@ -1,0 +1,74 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+describe('sentry test-kit test suite - user feedback', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      transport: sentryTransport,
+    })
+  )
+
+  beforeEach(() => testkit.reset())
+
+  test('feedback() is empty when nothing was submitted', () => {
+    expect(testkit.feedback()).toEqual([])
+  })
+
+  test('captures a submitted feedback with its message and contact fields', async () => {
+    Sentry.captureFeedback({
+      message: 'the checkout page is confusing',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      url: 'https://shop.example.com/checkout',
+    })
+    const [feedback] = await testkit.waitForFeedback(1)
+
+    expect(feedback!.message).toBe('the checkout page is confusing')
+    expect(feedback!.name).toBe('Jane Doe')
+    expect(feedback!.contactEmail).toBe('jane@example.com')
+    expect(feedback!.url).toBe('https://shop.example.com/checkout')
+    expect(feedback!.eventId).toEqual(expect.any(String))
+  })
+
+  test('links feedback to the associated error event', async () => {
+    const eventId = Sentry.captureException(new Error('boom'))
+    Sentry.captureFeedback({
+      message: 'this errored for me too',
+      associatedEventId: eventId,
+    })
+    const [feedback] = await testkit.waitForFeedback(1)
+
+    expect(feedback!.associatedEventId).toBe(eventId)
+  })
+
+  test('exposes the raw feedback event as originalFeedback', async () => {
+    Sentry.captureFeedback({ message: 'raw access' })
+    const [feedback] = await testkit.waitForFeedback(1)
+
+    expect(feedback!.originalFeedback.type).toBe('feedback')
+    expect(feedback!.originalFeedback.contexts.feedback.message).toBe(
+      'raw access'
+    )
+  })
+
+  test('does not record feedback as a report', async () => {
+    Sentry.captureFeedback({ message: 'not an error' })
+    await testkit.waitForFeedback(1)
+
+    expect(testkit.reports()).toHaveLength(0)
+  })
+
+  test('reset() clears captured feedback', async () => {
+    Sentry.captureFeedback({ message: 'to be cleared' })
+    await testkit.waitForFeedback(1)
+
+    testkit.reset()
+
+    expect(testkit.feedback()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -144,6 +144,52 @@ describe('handleEnvelopeRequestData', () => {
     expect(testkit.reports()).toHaveLength(1)
   })
 
+  test('captures a feedback item', () => {
+    const testkit = createTestkit()
+    const feedbackPayload = JSON.stringify({
+      type: 'feedback',
+      event_id: 'fb123',
+      contexts: {
+        feedback: {
+          message: 'great tool',
+          contact_email: 'jane@example.com',
+          associated_event_id: 'evt456',
+        },
+      },
+    })
+    const body = `${envelopeHeader}\n{"type":"feedback"}\n${feedbackPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.feedback()).toHaveLength(1)
+    expect(testkit.feedback()[0]!.message).toBe('great tool')
+    expect(testkit.feedback()[0]!.contactEmail).toBe('jane@example.com')
+    expect(testkit.feedback()[0]!.associatedEventId).toBe('evt456')
+    expect(testkit.feedback()[0]!.eventId).toBe('fb123')
+    expect(testkit.reports()).toHaveLength(0)
+  })
+
+  test('captures a check_in item', () => {
+    const testkit = createTestkit()
+    const checkInPayload = JSON.stringify({
+      check_in_id: 'ci789',
+      monitor_slug: 'nightly-report',
+      status: 'ok',
+      duration: 3.2,
+      release: '1.0.0',
+      environment: 'production',
+    })
+    const body = `${envelopeHeader}\n{"type":"check_in"}\n${checkInPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.checkIns()).toHaveLength(1)
+    expect(testkit.checkIns()[0]!.checkInId).toBe('ci789')
+    expect(testkit.checkIns()[0]!.monitorSlug).toBe('nightly-report')
+    expect(testkit.checkIns()[0]!.status).toBe('ok')
+    expect(testkit.checkIns()[0]!.duration).toBe(3.2)
+  })
+
   test('ignores unknown item types without throwing', () => {
     const testkit = createTestkit()
     const body = `${envelopeHeader}\n{"type":"session"}\n${sessionPayload}`

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -1,4 +1,6 @@
 import {
+  transformCheckIn,
+  transformFeedback,
   transformLog,
   transformReport,
   transformTransaction,
@@ -131,6 +133,10 @@ export function handleEnvelopeRequestData(
       // Log items are containers: their payload is { items: SerializedLog[] }
       const logs = (payload && payload.items) || []
       logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
+    } else if (header.type === 'feedback') {
+      testkit.feedback().push(transformFeedback(payload))
+    } else if (header.type === 'check_in') {
+      testkit.checkIns().push(transformCheckIn(payload))
     }
   })
 }

--- a/packages/sentry-testkit/src/sentryTransport.ts
+++ b/packages/sentry-testkit/src/sentryTransport.ts
@@ -1,5 +1,7 @@
 import { Event } from '@sentry/types'
 import {
+  transformCheckIn,
+  transformFeedback,
   transformLog,
   transformReport,
   transformTransaction,
@@ -36,6 +38,10 @@ export function createSentryTransport(testkit: Testkit): any {
           // Log items are containers: their payload is { items: SerializedLog[] }
           const logs = (data && data.items) || []
           logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
+        } else if (headers.type === 'feedback') {
+          testkit.feedback().push(transformFeedback(data))
+        } else if (headers.type === 'check_in') {
+          testkit.checkIns().push(transformCheckIn(data))
         }
       })
 

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -1,10 +1,20 @@
 import { parseEnvelope } from './parsers'
 import {
+  transformCheckIn,
+  transformFeedback,
   transformLog,
   transformReport,
   transformTransaction,
 } from './transformers'
-import { Log, Report, ReportError, Testkit, Transaction } from './types'
+import {
+  CheckIn,
+  FeedbackReport,
+  Log,
+  Report,
+  ReportError,
+  Testkit,
+  Transaction,
+} from './types'
 
 function getException(report: Report) {
   return report.error
@@ -46,6 +56,8 @@ export function createTestkit(): Testkit {
   let reports: Report[] = []
   let transactions: Transaction[] = []
   let logs: Log[] = []
+  let feedback: FeedbackReport[] = []
+  let checkIns: CheckIn[] = []
 
   const createRequestHandler = (baseUrl: string) => (request: any) => {
     const url = request.url()
@@ -65,6 +77,10 @@ export function createTestkit(): Testkit {
         } else if (header.type === 'log') {
           const items = (payload && payload.items) || []
           items.forEach((log: any) => logs.push(transformLog(log)))
+        } else if (header.type === 'feedback') {
+          feedback.push(transformFeedback(payload))
+        } else if (header.type === 'check_in') {
+          checkIns.push(transformCheckIn(payload))
         }
       })
     }
@@ -102,6 +118,14 @@ export function createTestkit(): Testkit {
       return logs
     },
 
+    feedback() {
+      return feedback
+    },
+
+    checkIns() {
+      return checkIns
+    },
+
     waitForReports(count, options) {
       return waitFor('reports', () => reports, count, options)
     },
@@ -114,10 +138,20 @@ export function createTestkit(): Testkit {
       return waitFor('logs', () => logs, count, options)
     },
 
+    waitForFeedback(count, options) {
+      return waitFor('feedback', () => feedback, count, options)
+    },
+
+    waitForCheckIns(count, options) {
+      return waitFor('check-ins', () => checkIns, count, options)
+    },
+
     reset() {
       reports = []
       transactions = []
       logs = []
+      feedback = []
+      checkIns = []
     },
 
     getExceptionAt(index: number) {

--- a/packages/sentry-testkit/src/transformers.ts
+++ b/packages/sentry-testkit/src/transformers.ts
@@ -1,4 +1,11 @@
-import { Log, Report, ReportError, Transaction } from './types'
+import {
+  CheckIn,
+  FeedbackReport,
+  Log,
+  Report,
+  ReportError,
+  Transaction,
+} from './types'
 
 export function transformReport(report: any): Report {
   const exception =
@@ -44,6 +51,33 @@ export function transformLog(log: any): Log {
     traceId: log.trace_id,
     severityNumber: log.severity_number,
     originalLog: log,
+  }
+}
+
+export function transformFeedback(event: any): FeedbackReport {
+  const feedback = event.contexts?.feedback ?? {}
+  return {
+    message: feedback.message,
+    name: feedback.name,
+    contactEmail: feedback.contact_email,
+    url: feedback.url,
+    associatedEventId: feedback.associated_event_id,
+    source: feedback.source,
+    replayId: feedback.replay_id,
+    eventId: event.event_id,
+    originalFeedback: event,
+  }
+}
+
+export function transformCheckIn(checkIn: any): CheckIn {
+  return {
+    checkInId: checkIn.check_in_id,
+    monitorSlug: checkIn.monitor_slug,
+    status: checkIn.status,
+    duration: checkIn.duration,
+    release: checkIn.release,
+    environment: checkIn.environment,
+    originalCheckIn: checkIn,
   }
 }
 

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -81,6 +81,30 @@ declare namespace sentryTestkit {
     originalLog: any
   }
 
+  interface FeedbackReport {
+    message: string
+    name?: string
+    contactEmail?: string
+    url?: string
+    associatedEventId?: string
+    source?: string
+    replayId?: string
+    eventId?: string
+    originalFeedback: any
+  }
+
+  type CheckInStatus = 'in_progress' | 'ok' | 'error'
+
+  interface CheckIn {
+    checkInId: string
+    monitorSlug: string
+    status: CheckInStatus
+    duration?: number
+    release?: string
+    environment?: string
+    originalCheckIn: any
+  }
+
   interface WaitForOptions {
     timeout?: number
   }
@@ -97,12 +121,19 @@ declare namespace sentryTestkit {
     reports(): Report[]
     transactions(): Transaction[]
     logs(): Log[]
+    feedback(): FeedbackReport[]
+    checkIns(): CheckIn[]
     waitForReports(count: number, options?: WaitForOptions): Promise<Report[]>
     waitForTransactions(
       count: number,
       options?: WaitForOptions
     ): Promise<Transaction[]>
     waitForLogs(count: number, options?: WaitForOptions): Promise<Log[]>
+    waitForFeedback(
+      count: number,
+      options?: WaitForOptions
+    ): Promise<FeedbackReport[]>
+    waitForCheckIns(count: number, options?: WaitForOptions): Promise<CheckIn[]>
     reset(): void
     getExceptionAt(index: number): ReportError | undefined
     findReport(e: Error): Report | undefined


### PR DESCRIPTION
## Summary

Adds two more Sentry envelope item types to the testkit from the roadmap (#313), both following the data-type pattern established by structured logs (#300): a transformer, routing in every capture mode, an accessor, an awaitable `waitFor*` helper, and `reset()` clearing.

### #301 - User Feedback -> `testkit.feedback()`
Captures `feedback` envelope items from `Sentry.captureFeedback(...)` or the feedback widget. Each `FeedbackReport` exposes `message`, `name`, `contactEmail`, `url`, `associatedEventId` (link to the error the feedback is about), `source`, `replayId`, `eventId`, and the raw event as `originalFeedback`.

### #302 - Cron Check-Ins -> `testkit.checkIns()`
Captures `check_in` envelope items from `Sentry.captureCheckIn(...)` / `Sentry.withMonitor(...)`. Each `CheckIn` exposes `checkInId` (correlates an `in_progress` with its terminal `ok`/`error`), `monitorSlug`, `status`, `duration`, `release`, `environment`, and the raw payload as `originalCheckIn`.

Both are routed in all capture modes (transport, local server, network interceptor, Puppeteer/Playwright), cleared by `testkit.reset()`, and have `waitForFeedback` / `waitForCheckIns` helpers with the same signature as `waitForReports`.

## Test plan

- New `__tests__/feedback.test.ts` and `__tests__/checkins.test.ts` drive the real `@sentry/node` `captureFeedback` / `captureCheckIn` APIs end-to-end through the transport: field mapping, error-event linkage, in_progress -> ok correlation with duration, `originalX` raw access, isolation from `reports()`, and `reset()`.
- New raw-envelope routing cases in `__tests__/parsers.test.ts` (local-server/interceptor/Puppeteer path).
- Full suite green: 14 suites, 195 tests (`yarn build`, `yarn lint`, `yarn test`).
- Docs: `feedback()` and `checkIns()` API reference sections added; `yarn workspace sentry-testkit-docs build` passes with no new broken links.

Closes #301
Closes #302