### PR TITLE
feat: capture application metrics via testkit.metrics()

### DIFF
--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -13,11 +13,12 @@ Sentry Testkit consists of a very simple and strait-forward API using the follow
 * [`reports()`](#reports) — captured errors and messages
 * [`transactions()`](#transactions) — captured performance transactions
 * [`logs()`](#logs) — captured structured logs
+* [`metrics()`](#metrics) — captured application metrics
 * [`feedback()`](#feedback) — captured user feedback
 * [`checkIns()`](#checkins) — captured cron monitor check-ins
 
 **Awaiting asynchronously-sent data**
-* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForFeedback`, `waitForCheckIns`
+* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForMetrics`, `waitForFeedback`, `waitForCheckIns`
 
 **Finding and filtering**
 * [`findReport(error)`](#findreporterror)
@@ -87,7 +88,7 @@ test('waitForReports example', async function() {
 })
 ```
 
-Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)` and `waitForLogs(count, options)`.
+Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)`, `waitForLogs(count, options)`, `waitForMetrics(count, options)`, `waitForFeedback(count, options)` and `waitForCheckIns(count, options)`.
 
 ### `findReport(error)`
 Finds a report by a given error.
@@ -258,6 +259,41 @@ test('logs example', async function() {
     expect(log.attributes.userId).toEqual(42)
 })
 ```
+
+### `metrics()`
+Gets all captured [application metrics](https://docs.sentry.io/platforms/javascript/metrics/) emitted via `Sentry.metrics.count(...)`, `Sentry.metrics.gauge(...)` or `Sentry.metrics.distribution(...)` (Sentry SDK v10 and above).
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>Metric</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | <code>string</code> | The metric name, e.g. `api.requests` |
+| `type` | <code>string</code> | `counter` \| `gauge` \| `distribution` |
+| `value` | <code>number</code> | The reported value |
+| `unit` | <code>string</code> | The unit, e.g. `millisecond`, if provided |
+| `attributes` | <code>Object</code> | Metric attributes as plain values, e.g. `{ endpoint: '/api/users' }` |
+| `timestamp` | <code>number</code> | Epoch time in seconds |
+| `traceId` | <code>string</code> | The trace this metric belongs to, if any |
+| `spanId` | <code>string</code> | The span this metric was emitted from, if any |
+| `originalMetric` | <code>Object</code> | The raw metric item as sent by the SDK |
+
+Metrics are batched by the SDK, so flush before asserting on them.
+
+For example
+```javascript
+test('metrics example', async function() {
+    Sentry.metrics.count('api.requests', 1, { attributes: { endpoint: '/api/users' } })
+    await Sentry.flush()
+
+    const [metric] = testkit.metrics()
+    expect(metric.name).toEqual('api.requests')
+    expect(metric.type).toEqual('counter')
+    expect(metric.value).toEqual(1)
+    expect(metric.attributes.endpoint).toEqual('/api/users')
+})
+```
+
+Alongside the attributes you set, the SDK enriches every metric with its own — `sentry.release`, `sentry.environment`, `sentry.sdk.name` and more — so assert on the specific attributes you care about rather than on the whole object.
 
 ### `feedback()`
 Gets all captured [user feedback](https://docs.sentry.io/platforms/javascript/user-feedback/) submitted via `Sentry.captureFeedback(...)` or the feedback widget.

--- a/packages/sentry-testkit-docs/docs/getting-started.md
+++ b/packages/sentry-testkit-docs/docs/getting-started.md
@@ -44,11 +44,12 @@ test('collect performance events', function () {
 });
 ```
 
-### Beyond errors: logs, feedback and check-ins
+### Beyond errors: logs, metrics, feedback and check-ins
 
 `sentry-testkit` captures more than errors and transactions. If your app uses these Sentry features, you can assert on them the same way — each has its own accessor and an awaitable `waitFor*` helper:
 
 - **[Structured logs](/docs/api#logs)** — everything sent via `Sentry.logger.*` (requires `enableLogs: true` in `Sentry.init`), via `testkit.logs()`
+- **[Application metrics](/docs/api#metrics)** — counters, gauges and distributions from `Sentry.metrics.*` (Sentry SDK v10 and above), via `testkit.metrics()`
 - **[User feedback](/docs/api#feedback)** — submissions from `Sentry.captureFeedback(...)` or the feedback widget, via `testkit.feedback()`
 - **[Cron check-ins](/docs/api#checkins)** — monitor check-ins from `Sentry.captureCheckIn(...)` / `Sentry.withMonitor(...)`, via `testkit.checkIns()`
 

--- a/packages/sentry-testkit/__tests__/metrics.test.ts
+++ b/packages/sentry-testkit/__tests__/metrics.test.ts
@@ -1,0 +1,125 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+// Application metrics are a Sentry SDK v10 feature; v9, which CI also runs
+// against, has no metrics API at all, so the suite has nothing to drive there
+const metrics = (Sentry as any).metrics
+const describeMetrics =
+  typeof metrics?.count === 'function' ? describe : describe.skip
+
+describeMetrics('sentry test-kit test suite - application metrics', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      environment: 'ci',
+      enableMetrics: true,
+      transport: sentryTransport,
+    })
+  )
+
+  beforeEach(() => testkit.reset())
+
+  test('metrics() is empty when nothing was emitted', () => {
+    expect(testkit.metrics()).toEqual([])
+  })
+
+  test('captures a counter with its name, type and value', async () => {
+    metrics.count('api.requests', 3)
+    await Sentry.flush()
+
+    expect(testkit.metrics()).toHaveLength(1)
+    const metric = testkit.metrics()[0]!
+    expect(metric.name).toBe('api.requests')
+    expect(metric.type).toBe('counter')
+    expect(metric.value).toBe(3)
+    expect(metric.timestamp).toEqual(expect.any(Number))
+    expect(metric.traceId).toEqual(expect.any(String))
+  })
+
+  test('captures a gauge with its unit', async () => {
+    metrics.gauge('memory.usage', 1024, { unit: 'megabyte' })
+    await Sentry.flush()
+
+    expect(testkit.metrics()).toHaveLength(1)
+    const metric = testkit.metrics()[0]!
+    expect(metric.name).toBe('memory.usage')
+    expect(metric.type).toBe('gauge')
+    expect(metric.value).toBe(1024)
+    expect(metric.unit).toBe('megabyte')
+  })
+
+  test('captures a distribution', async () => {
+    metrics.distribution('request.duration', 235, { unit: 'millisecond' })
+    await Sentry.flush()
+
+    expect(testkit.metrics()).toHaveLength(1)
+    const metric = testkit.metrics()[0]!
+    expect(metric.name).toBe('request.duration')
+    expect(metric.type).toBe('distribution')
+    expect(metric.value).toBe(235)
+  })
+
+  test('unwraps typed attributes to plain values', async () => {
+    metrics.count('api.requests', 1, {
+      attributes: { endpoint: '/api/users', status: 200, cached: false },
+    })
+    await Sentry.flush()
+
+    expect(testkit.metrics()).toHaveLength(1)
+    const metric = testkit.metrics()[0]!
+    expect(metric.attributes['endpoint']).toBe('/api/users')
+    expect(metric.attributes['status']).toBe(200)
+    expect(metric.attributes['cached']).toBe(false)
+    expect(metric.attributes['sentry.release']).toBe('test')
+    expect(metric.attributes['sentry.environment']).toBe('ci')
+  })
+
+  test('captures multiple metrics batched in a single envelope item', async () => {
+    metrics.count('items.processed', 5)
+    metrics.gauge('queue.depth', 12)
+    await Sentry.flush()
+
+    expect(testkit.metrics().map(metric => metric.name)).toEqual([
+      'items.processed',
+      'queue.depth',
+    ])
+    expect(testkit.metrics().map(metric => metric.value)).toEqual([5, 12])
+  })
+
+  test('exposes the raw serialized metric as originalMetric', async () => {
+    metrics.count('raw.metric', 1)
+    await Sentry.flush()
+
+    const metric = testkit.metrics()[0]!
+    expect(metric.originalMetric.name).toBe('raw.metric')
+    expect(metric.originalMetric.type).toBe('counter')
+  })
+
+  test('waitForMetrics resolves once the expected count is reached', async () => {
+    metrics.count('awaited.metric', 1)
+    Sentry.flush()
+
+    const captured = await testkit.waitForMetrics(1)
+    expect(captured[0]!.name).toBe('awaited.metric')
+  })
+
+  test('waitForMetrics rejects with a descriptive error on timeout', async () => {
+    await expect(testkit.waitForMetrics(1, { timeout: 50 })).rejects.toThrow(
+      'Expected at least 1 metrics within 50ms, but only 0 were captured'
+    )
+  })
+
+  test('reset() clears captured metrics', async () => {
+    metrics.count('to.be.cleared', 1)
+    await Sentry.flush()
+    expect(testkit.metrics()).toHaveLength(1)
+
+    testkit.reset()
+
+    expect(testkit.metrics()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -144,6 +144,53 @@ describe('handleEnvelopeRequestData', () => {
     expect(testkit.reports()).toHaveLength(1)
   })
 
+  test('captures metrics from a trace_metric container item', () => {
+    const testkit = createTestkit()
+    const metricItems = JSON.stringify({
+      items: [
+        {
+          timestamp: 1717081538.235,
+          trace_id: 'abcd1234',
+          span_id: 'ef567890',
+          name: 'api.requests',
+          type: 'counter',
+          value: 3,
+          attributes: {
+            endpoint: { value: '/api/users', type: 'string' },
+            cached: { value: false, type: 'boolean' },
+          },
+        },
+        {
+          timestamp: 1717081539.001,
+          trace_id: 'abcd1234',
+          name: 'memory.usage',
+          type: 'gauge',
+          unit: 'megabyte',
+          value: 1024,
+        },
+      ],
+    })
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"trace_metric","item_count":2,"content_type":"application/vnd.sentry.items.trace-metric+json"}\n` +
+      `${metricItems}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.metrics()).toHaveLength(2)
+    expect(testkit.metrics()[0]!.name).toBe('api.requests')
+    expect(testkit.metrics()[0]!.type).toBe('counter')
+    expect(testkit.metrics()[0]!.value).toBe(3)
+    expect(testkit.metrics()[0]!.traceId).toBe('abcd1234')
+    expect(testkit.metrics()[0]!.spanId).toBe('ef567890')
+    expect(testkit.metrics()[0]!.attributes['endpoint']).toBe('/api/users')
+    expect(testkit.metrics()[0]!.attributes['cached']).toBe(false)
+    expect(testkit.metrics()[1]!.name).toBe('memory.usage')
+    expect(testkit.metrics()[1]!.unit).toBe('megabyte')
+    expect(testkit.reports()).toHaveLength(1)
+  })
+
   test('captures a feedback item', () => {
     const testkit = createTestkit()
     const feedbackPayload = JSON.stringify({

--- a/packages/sentry-testkit/__tests__/puppeteer.test.ts
+++ b/packages/sentry-testkit/__tests__/puppeteer.test.ts
@@ -22,6 +22,12 @@ describe('Puppeteer testkit', () => {
       {"type":"transaction","sample_rates":[{"id":"client_rate","rate":1}]}
       {"contexts":{"trace":{"op":"transaction","span_id":"9ce5f4be9f39417f","trace_id":"57909d703068487a9e3cff52a6279484"}},"spans":[{"description":"child-description","op":"child-span","parent_span_id":"9ce5f4be9f39417f","span_id":"b12b5d02ec5f7b1c","start_timestamp":1623430659.9326224,"timestamp":1623430659.9327486,"trace_id":"57909d703068487a9e3cff52a6279484"}],"start_timestamp":1623430659.93125,"tags":{},"timestamp":1623430659.9330351,"transaction":"transaction-name","type":"transaction","platform":"node","event_id":"601fdd0eb40343f08274857951e483de","environment":"production","sdk":{"integrations":["InboundFilters","FunctionToString","Console","Http","OnUncaughtException","OnUnhandledRejection","LinkedErrors"],"name":"sentry.javascript.node","version":"6.6.0","packages":[{"name":"npm:@sentry/node","version":"6.6.0"}]}}`,
   })
+  const sentryMetricRequest = {
+    url: () => 'https://sentry.io/api/1234567/envelope',
+    postData: () => `{"sdk":{"name":"sentry.javascript.browser","version":"10.46.0"}}
+{"type":"trace_metric","item_count":1,"content_type":"application/vnd.sentry.items.trace-metric+json"}
+{"items":[{"timestamp":1717081538.235,"trace_id":"abcd1234","name":"api.requests","type":"counter","value":3,"unit":"none","attributes":{"endpoint":{"value":"/api/users","type":"string"}}}]}`,
+  }
   const sentrySessionRequest = {
     url: () => 'https://sentry.io/api/1234567/envelope',
     postData: () => `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.react","version":"6.11.0"}}
@@ -47,6 +53,17 @@ describe('Puppeteer testkit', () => {
     page.emit('request', createSentryPerfRequest())
     expect(testkit.transactions()).toHaveLength(1)
     expect(testkit.transactions()[0]!.name).toEqual('transaction-name')
+  })
+
+  test('should collect metrics from a trace_metric envelope item', () => {
+    testkit.puppeteer.startListening(page)
+    page.emit('request', sentryMetricRequest)
+    expect(testkit.metrics()).toHaveLength(1)
+    const metric = testkit.metrics()[0]!
+    expect(metric.name).toEqual('api.requests')
+    expect(metric.type).toEqual('counter')
+    expect(metric.value).toEqual(3)
+    expect(metric.attributes['endpoint']).toEqual('/api/users')
   })
 
   test('should handle session items in an envelope request', () => {

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -2,6 +2,7 @@ import {
   transformCheckIn,
   transformFeedback,
   transformLog,
+  transformMetric,
   transformReport,
   transformTransaction,
 } from './transformers'
@@ -133,6 +134,12 @@ export function handleEnvelopeRequestData(
       // Log items are containers: their payload is { items: SerializedLog[] }
       const logs = (payload && payload.items) || []
       logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
+    } else if (header.type === 'trace_metric') {
+      // Metric items are containers: their payload is { items: SerializedMetric[] }
+      const metrics = (payload && payload.items) || []
+      metrics.forEach((metric: any) =>
+        testkit.metrics().push(transformMetric(metric))
+      )
     } else if (header.type === 'feedback') {
       testkit.feedback().push(transformFeedback(payload))
     } else if (header.type === 'check_in') {

--- a/packages/sentry-testkit/src/sentryTransport.ts
+++ b/packages/sentry-testkit/src/sentryTransport.ts
@@ -3,6 +3,7 @@ import {
   transformCheckIn,
   transformFeedback,
   transformLog,
+  transformMetric,
   transformReport,
   transformTransaction,
 } from './transformers'
@@ -38,6 +39,12 @@ export function createSentryTransport(testkit: Testkit): any {
           // Log items are containers: their payload is { items: SerializedLog[] }
           const logs = (data && data.items) || []
           logs.forEach((log: any) => testkit.logs().push(transformLog(log)))
+        } else if (headers.type === 'trace_metric') {
+          // Metric items are containers: their payload is { items: SerializedMetric[] }
+          const metrics = (data && data.items) || []
+          metrics.forEach((metric: any) =>
+            testkit.metrics().push(transformMetric(metric))
+          )
         } else if (headers.type === 'feedback') {
           testkit.feedback().push(transformFeedback(data))
         } else if (headers.type === 'check_in') {

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -3,6 +3,7 @@ import {
   transformCheckIn,
   transformFeedback,
   transformLog,
+  transformMetric,
   transformReport,
   transformTransaction,
 } from './transformers'
@@ -10,6 +11,7 @@ import {
   CheckIn,
   FeedbackReport,
   Log,
+  Metric,
   Report,
   ReportError,
   Testkit,
@@ -56,6 +58,7 @@ export function createTestkit(): Testkit {
   let reports: Report[] = []
   let transactions: Transaction[] = []
   let logs: Log[] = []
+  let metrics: Metric[] = []
   let feedback: FeedbackReport[] = []
   let checkIns: CheckIn[] = []
 
@@ -77,6 +80,9 @@ export function createTestkit(): Testkit {
         } else if (header.type === 'log') {
           const items = (payload && payload.items) || []
           items.forEach((log: any) => logs.push(transformLog(log)))
+        } else if (header.type === 'trace_metric') {
+          const items = (payload && payload.items) || []
+          items.forEach((metric: any) => metrics.push(transformMetric(metric)))
         } else if (header.type === 'feedback') {
           feedback.push(transformFeedback(payload))
         } else if (header.type === 'check_in') {
@@ -118,6 +124,10 @@ export function createTestkit(): Testkit {
       return logs
     },
 
+    metrics() {
+      return metrics
+    },
+
     feedback() {
       return feedback
     },
@@ -138,6 +148,10 @@ export function createTestkit(): Testkit {
       return waitFor('logs', () => logs, count, options)
     },
 
+    waitForMetrics(count, options) {
+      return waitFor('metrics', () => metrics, count, options)
+    },
+
     waitForFeedback(count, options) {
       return waitFor('feedback', () => feedback, count, options)
     },
@@ -150,6 +164,7 @@ export function createTestkit(): Testkit {
       reports = []
       transactions = []
       logs = []
+      metrics = []
       feedback = []
       checkIns = []
     },

--- a/packages/sentry-testkit/src/transformers.ts
+++ b/packages/sentry-testkit/src/transformers.ts
@@ -2,10 +2,24 @@ import {
   CheckIn,
   FeedbackReport,
   Log,
+  Metric,
   Report,
   ReportError,
   Transaction,
 } from './types'
+
+// Serialized attributes are typed wrappers, e.g. { value: 42, type: 'integer' }
+function unwrapAttributes(rawAttributes: any): { [key: string]: any } {
+  const attributes: { [key: string]: any } = {}
+  Object.keys(rawAttributes || {}).forEach(key => {
+    const attribute = rawAttributes[key]
+    attributes[key] =
+      attribute && typeof attribute === 'object' && 'value' in attribute
+        ? attribute.value
+        : attribute
+  })
+  return attributes
+}
 
 export function transformReport(report: any): Report {
   const exception =
@@ -33,24 +47,28 @@ export function transformReport(report: any): Report {
 }
 
 export function transformLog(log: any): Log {
-  // Serialized log attributes are typed wrappers, e.g. { value: 42, type: 'integer' }
-  const attributes: { [key: string]: any } = {}
-  Object.keys(log.attributes || {}).forEach(key => {
-    const attribute = log.attributes[key]
-    attributes[key] =
-      attribute && typeof attribute === 'object' && 'value' in attribute
-        ? attribute.value
-        : attribute
-  })
-
   return {
     level: log.level,
     message: log.body,
-    attributes,
+    attributes: unwrapAttributes(log.attributes),
     timestamp: log.timestamp,
     traceId: log.trace_id,
     severityNumber: log.severity_number,
     originalLog: log,
+  }
+}
+
+export function transformMetric(metric: any): Metric {
+  return {
+    name: metric.name,
+    type: metric.type,
+    value: metric.value,
+    unit: metric.unit,
+    attributes: unwrapAttributes(metric.attributes),
+    timestamp: metric.timestamp,
+    traceId: metric.trace_id,
+    spanId: metric.span_id,
+    originalMetric: metric,
   }
 }
 

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -93,6 +93,20 @@ declare namespace sentryTestkit {
     originalFeedback: any
   }
 
+  type MetricType = 'counter' | 'gauge' | 'distribution'
+
+  interface Metric {
+    name: string
+    type: MetricType
+    value: number
+    unit?: string
+    attributes: { [key: string]: any }
+    timestamp: number
+    traceId?: string
+    spanId?: string
+    originalMetric: any
+  }
+
   type CheckInStatus = 'in_progress' | 'ok' | 'error'
 
   interface CheckIn {
@@ -121,6 +135,7 @@ declare namespace sentryTestkit {
     reports(): Report[]
     transactions(): Transaction[]
     logs(): Log[]
+    metrics(): Metric[]
     feedback(): FeedbackReport[]
     checkIns(): CheckIn[]
     waitForReports(count: number, options?: WaitForOptions): Promise<Report[]>
@@ -129,6 +144,7 @@ declare namespace sentryTestkit {
       options?: WaitForOptions
     ): Promise<Transaction[]>
     waitForLogs(count: number, options?: WaitForOptions): Promise<Log[]>
+    waitForMetrics(count: number, options?: WaitForOptions): Promise<Metric[]>
     waitForFeedback(
       count: number,
       options?: WaitForOptions


### PR DESCRIPTION
## What does this change?

Adds capture of Sentry's `trace_metric` envelope items, exposed via `testkit.metrics()` and `testkit.waitForMetrics(count, options)`. Closes #306.

## Why?

Application metrics (`Sentry.metrics.count` / `gauge` / `distribution`, Sentry SDK v10) were silently dropped, so users could not assert that a counter, gauge or distribution was emitted with the expected name, value, unit and attributes.

Each captured `Metric` exposes `name`, `type` (`counter` | `gauge` | `distribution`), `value`, `unit`, `attributes` (unwrapped from their typed wrappers, as logs already do), `timestamp`, `traceId`, `spanId`, and the raw item as `originalMetric`. `reset()` clears them.

Metric items are containers holding a batch of metrics, so one envelope item can yield several captured metrics. The typed-attribute unwrapping shared with logs is now a small `unwrapAttributes` helper in `transformers.ts`.

## Type of change

- [ ] `fix:` — bug fix (patch)
- [x] `feat:` — new feature (minor)
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change (major)
- [ ] `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` — no release impact

Only additions to `types.ts`, so minor.

## Checklist

**Code**
- [x] New envelope item type? All three dispatch sites updated (`parsers.ts`, `testkit.ts`, `sentryTransport.ts`)
- [x] `browser.ts` still imports nothing from Node or Express
- [x] Works on both `@sentry/*` v9 and v10

**Quality**
- [x] `yarn lint` passes
- [x] `yarn build` passes (this is the type check)
- [x] No new `@ts-ignore` or `as` casts in `src/`
- [x] Commit type above matches the actual semver impact of any `types.ts` change

**Tests**
- [x] `yarn test` passes
- [x] Tests added or updated, driving the real Sentry SDK rather than a mock
- [x] Covers each integration mode the change affects
- [x] Verified the new test fails without the change

New `__tests__/metrics.test.ts` drives the real SDK in transport mode (counter, gauge, distribution, attributes, batching, `originalMetric`, `waitForMetrics`, `reset`). `parsers.test.ts` covers the local server and network interceptor path, `puppeteer.test.ts` the Puppeteer/Playwright path.

**Docs**
- [x] Public API change reflected in `packages/sentry-testkit-docs/docs/api/README.md`
- [x] Migration note added for breaking changes (n/a)
- [x] `CHANGELOG.md` not edited by hand

**Hygiene**
- [x] Rebased on `master` and squashed to a single conventional commit
- [x] No emojis, no AI-attribution trailers, no stray `console.log`

## Note on the v9 matrix leg

`@sentry/core@9` ships no metrics API at all, so `metrics.test.ts` guards its `describe` and skips when `Sentry.metrics.count` is absent. On the v9 CI leg there is nothing to drive; coverage there comes from the parser and Puppeteer fixture tests, which exercise the same routing.
