### PR TITLE
feat: capture attachments and expose them on the report they were sent with

### DIFF
--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -14,11 +14,12 @@ Sentry Testkit consists of a very simple and strait-forward API using the follow
 * [`transactions()`](#transactions) — captured performance transactions
 * [`logs()`](#logs) — captured structured logs
 * [`metrics()`](#metrics) — captured application metrics
+* [`attachments()`](#attachments) — captured event attachments
 * [`feedback()`](#feedback) — captured user feedback
 * [`checkIns()`](#checkins) — captured cron monitor check-ins
 
 **Awaiting asynchronously-sent data**
-* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForMetrics`, `waitForFeedback`, `waitForCheckIns`
+* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForMetrics`, `waitForAttachments`, `waitForFeedback`, `waitForCheckIns`
 
 **Finding and filtering**
 * [`findReport(error)`](#findreporterror)
@@ -69,6 +70,8 @@ Each report also exposes evaluated [feature flags](https://docs.sentry.io/platfo
 expect(testkit.reports()[0].flags).toEqual([{ flag: 'new-checkout', result: true }])
 ```
 
+Files sent with the event are exposed as `report.attachments` — see [`attachments()`](#attachments) — and the array is empty when the event carried none.
+
 ### `waitForReports(count, options)`
 Waits until at least `count` reports have been captured. This replaces "sleep then assert" patterns and third-party polling helpers — Sentry transports are asynchronous, so reports may not be captured yet when your assertion runs.
 
@@ -88,7 +91,7 @@ test('waitForReports example', async function() {
 })
 ```
 
-Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)`, `waitForLogs(count, options)`, `waitForMetrics(count, options)`, `waitForFeedback(count, options)` and `waitForCheckIns(count, options)`.
+Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)`, `waitForLogs(count, options)`, `waitForMetrics(count, options)`, `waitForAttachments(count, options)`, `waitForFeedback(count, options)` and `waitForCheckIns(count, options)`.
 
 ### `findReport(error)`
 Finds a report by a given error.
@@ -294,6 +297,52 @@ test('metrics example', async function() {
 ```
 
 Alongside the attributes you set, the SDK enriches every metric with its own — `sentry.release`, `sentry.environment`, `sentry.sdk.name` and more — so assert on the specific attributes you care about rather than on the whole object.
+
+### `attachments()`
+Gets all captured [attachments](https://docs.sentry.io/platforms/javascript/enriching-events/attachments/) — files sent with an event via `scope.addAttachment(...)` or the `attachments` capture option.
+
+**Returns**: <code>Array</code> - where each member of the array consists of an <code>Attachment</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `filename` | <code>string</code> | The attachment's filename |
+| `contentType` | <code>string</code> | The declared content type, if any |
+| `attachmentType` | <code>string</code> | The Sentry attachment type, e.g. `event.attachment`, if any |
+| `data` | <code>Uint8Array</code> | The attachment bytes, exactly as sent |
+| `text` | <code>string</code> | The bytes decoded as UTF-8, for asserting on text attachments |
+
+Attachments travel in the same envelope as the event they belong to, so they are also exposed on that report as `report.attachments`:
+
+```javascript
+test('attachments example', async function() {
+    Sentry.captureException(new Error('import failed'), {
+        attachments: [{ filename: 'import.csv', data: 'id,name\n1,jane', contentType: 'text/csv' }],
+    })
+
+    const [report] = await testkit.waitForReports(1)
+    expect(report.attachments).toHaveLength(1)
+    expect(report.attachments[0].filename).toEqual('import.csv')
+    expect(report.attachments[0].text).toEqual('id,name\n1,jane')
+})
+```
+
+Use `testkit.attachments()` when you do not care which event an attachment belongs to:
+
+```javascript
+test('scope attachment example', async function() {
+    Sentry.withScope(scope => {
+        scope.addAttachment({ filename: 'state.json', data: JSON.stringify({ cart: ['sku-1'] }) })
+        Sentry.captureException(new Error('checkout failed'))
+    })
+
+    const [attachment] = await testkit.waitForAttachments(1)
+    expect(JSON.parse(attachment.text)).toEqual({ cart: ['sku-1'] })
+})
+```
+
+:::note Binary attachments
+`data` holds the exact bytes whenever the testkit receives them as bytes: transport mode (Node, browser and React) always does, and so does the network interceptor when your interceptor hands the request body over as a `Buffer`. The local server, Puppeteer and Playwright receive the request body as text, so a binary attachment such as a screenshot arrives UTF-8 decoded there. Assert on binary payloads in transport mode.
+:::
 
 ### `feedback()`
 Gets all captured [user feedback](https://docs.sentry.io/platforms/javascript/user-feedback/) submitted via `Sentry.captureFeedback(...)` or the feedback widget.

--- a/packages/sentry-testkit-docs/docs/getting-started.md
+++ b/packages/sentry-testkit-docs/docs/getting-started.md
@@ -44,12 +44,13 @@ test('collect performance events', function () {
 });
 ```
 
-### Beyond errors: logs, metrics, feedback and check-ins
+### Beyond errors: logs, metrics, attachments, feedback and check-ins
 
 `sentry-testkit` captures more than errors and transactions. If your app uses these Sentry features, you can assert on them the same way — each has its own accessor and an awaitable `waitFor*` helper:
 
 - **[Structured logs](/docs/api#logs)** — everything sent via `Sentry.logger.*` (requires `enableLogs: true` in `Sentry.init`), via `testkit.logs()`
 - **[Application metrics](/docs/api#metrics)** — counters, gauges and distributions from `Sentry.metrics.*` (Sentry SDK v10 and above), via `testkit.metrics()`
+- **[Attachments](/docs/api#attachments)** — files sent with an event via `scope.addAttachment(...)` or the `attachments` capture option, via `testkit.attachments()` and `report.attachments`
 - **[User feedback](/docs/api#feedback)** — submissions from `Sentry.captureFeedback(...)` or the feedback widget, via `testkit.feedback()`
 - **[Cron check-ins](/docs/api#checkins)** — monitor check-ins from `Sentry.captureCheckIn(...)` / `Sentry.withMonitor(...)`, via `testkit.checkIns()`
 

--- a/packages/sentry-testkit/__tests__/attachments.test.ts
+++ b/packages/sentry-testkit/__tests__/attachments.test.ts
@@ -1,0 +1,116 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+describe('sentry test-kit test suite - attachments', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      transport: sentryTransport,
+    })
+  )
+
+  beforeEach(() => testkit.reset())
+
+  test('attachments() is empty when nothing was attached', () => {
+    expect(testkit.attachments()).toEqual([])
+  })
+
+  test('captures an attachment sent with an error', async () => {
+    Sentry.captureException(new Error('failed to import'), {
+      attachments: [
+        {
+          filename: 'import.csv',
+          data: 'id,name\n1,jane',
+          contentType: 'text/csv',
+        },
+      ],
+    })
+    const [attachment] = await testkit.waitForAttachments(1)
+
+    expect(attachment!.filename).toBe('import.csv')
+    expect(attachment!.contentType).toBe('text/csv')
+    expect(attachment!.text).toBe('id,name\n1,jane')
+  })
+
+  test('exposes attachments on the report they were sent with', async () => {
+    Sentry.captureException(new Error('failed to import'), {
+      attachments: [{ filename: 'import.csv', data: 'id,name\n1,jane' }],
+    })
+    const [report] = await testkit.waitForReports(1)
+
+    expect(report!.attachments).toHaveLength(1)
+    expect(report!.attachments[0]!.filename).toBe('import.csv')
+    expect(report!.attachments[0]!.text).toBe('id,name\n1,jane')
+  })
+
+  test('captures attachments added to the scope', async () => {
+    Sentry.withScope(scope => {
+      scope.addAttachment({ filename: 'scope.txt', data: 'from the scope' })
+      Sentry.captureException(new Error('scoped error'))
+    })
+    const [attachment] = await testkit.waitForAttachments(1)
+
+    expect(attachment!.filename).toBe('scope.txt')
+    expect(attachment!.text).toBe('from the scope')
+  })
+
+  test('captures several attachments sent with one error', async () => {
+    Sentry.captureException(new Error('two attachments'), {
+      attachments: [
+        { filename: 'first.txt', data: 'first' },
+        { filename: 'second.txt', data: 'second' },
+      ],
+    })
+    const attachments = await testkit.waitForAttachments(2)
+
+    expect(attachments.map(attachment => attachment.filename)).toEqual([
+      'first.txt',
+      'second.txt',
+    ])
+    const [report] = testkit.reports()
+    expect(report!.attachments).toHaveLength(2)
+  })
+
+  test('keeps binary attachment data intact', async () => {
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff])
+    Sentry.captureException(new Error('with a screenshot'), {
+      attachments: [
+        { filename: 'screenshot.png', data, contentType: 'image/png' },
+      ],
+    })
+    const [attachment] = await testkit.waitForAttachments(1)
+
+    expect(Array.from(attachment!.data)).toEqual(Array.from(data))
+  })
+
+  test('reports sent without attachments expose an empty array', async () => {
+    Sentry.captureException(new Error('no attachments here'))
+    const [report] = await testkit.waitForReports(1)
+
+    expect(report!.attachments).toEqual([])
+    expect(testkit.attachments()).toEqual([])
+  })
+
+  test('waitForAttachments rejects with a descriptive error on timeout', async () => {
+    await expect(
+      testkit.waitForAttachments(1, { timeout: 50 })
+    ).rejects.toThrow(
+      'Expected at least 1 attachments within 50ms, but only 0 were captured'
+    )
+  })
+
+  test('reset() clears captured attachments', async () => {
+    Sentry.captureException(new Error('to be cleared'), {
+      attachments: [{ filename: 'clear.txt', data: 'bye' }],
+    })
+    await testkit.waitForAttachments(1)
+
+    testkit.reset()
+
+    expect(testkit.attachments()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/__tests__/local-server.test.ts
+++ b/packages/sentry-testkit/__tests__/local-server.test.ts
@@ -90,6 +90,31 @@ describe('sentry test-kit test suite - local server', function() {
     expect(response.ok).toBe(true)
   })
 
+  test('should capture attachments sent alongside an event', async function() {
+    const dsn = localServer.getDsn()?.replace(`/${PROJECT_ID}`, '')
+    const attachmentPayload = 'id,name\n1,jane'
+    const envelopeBody =
+      `{"event_id":"9f2f0e1a","sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.node","version":"10.46.0"}}\n` +
+      `{"type":"attachment","length":${attachmentPayload.length},"filename":"import.csv","content_type":"text/csv"}\n` +
+      `${attachmentPayload}\n` +
+      `{"type":"event"}\n` +
+      `{"exception":{"values":[{"type":"Error","value":"import failed"}]},"level":"error","tags":{}}`
+
+    const response = await fetch(`${dsn}/api/${PROJECT_ID}/envelope/`, {
+      method: 'POST',
+      body: envelopeBody,
+      headers: { 'Content-Type': 'application/x-sentry-envelope' },
+    })
+
+    expect(response.ok).toBe(true)
+    await waitForExpect(() => expect(testkit.attachments()).toHaveLength(1))
+    const attachment = testkit.attachments()[0]!
+    expect(attachment.filename).toBe('import.csv')
+    expect(attachment.contentType).toBe('text/csv')
+    expect(attachment.text).toBe(attachmentPayload)
+    expect(testkit.reports()[0]!.attachments).toEqual([attachment])
+  })
+
   test('responds with Access-Control-Allow-Origin header', async function() {
     const dsn = localServer.getDsn()?.replace(`/${PROJECT_ID}`, '')
     const sessionEnvelopeBody =

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -72,6 +72,23 @@ describe('parseEnvelope', () => {
     expect(items[0]!.payload).toBe('plain text attachment')
   })
 
+  test('keeps the undecoded payload bytes of a binary item', () => {
+    const binaryPayload = Buffer.from([0x00, 0xff, 0x10, 0x7f])
+    const body = Buffer.concat([
+      Buffer.from(
+        `${envelopeHeader}\n` +
+          `{"type":"attachment","length":${binaryPayload.length},"filename":"blob.bin"}\n`
+      ),
+      binaryPayload,
+    ])
+
+    const items = parseEnvelope(body)
+
+    expect(Array.from(items[0]!.payloadBytes)).toEqual(
+      Array.from(binaryPayload)
+    )
+  })
+
   test('tolerates a trailing newline at the end of the envelope', () => {
     const body = `${envelopeHeader}\n{"type":"event"}\n${eventPayload}\n`
 
@@ -189,6 +206,50 @@ describe('handleEnvelopeRequestData', () => {
     expect(testkit.metrics()[1]!.name).toBe('memory.usage')
     expect(testkit.metrics()[1]!.unit).toBe('megabyte')
     expect(testkit.reports()).toHaveLength(1)
+  })
+
+  test('captures attachments and links them to the event of the same envelope', () => {
+    const testkit = createTestkit()
+    const attachmentPayload = 'first line\nsecond line'
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"attachment","length":${attachmentPayload.length},"filename":"log.txt","content_type":"text/plain"}\n` +
+      `${attachmentPayload}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.attachments()).toHaveLength(1)
+    const attachment = testkit.attachments()[0]!
+    expect(attachment.filename).toBe('log.txt')
+    expect(attachment.contentType).toBe('text/plain')
+    expect(attachment.text).toBe(attachmentPayload)
+
+    expect(testkit.reports()).toHaveLength(1)
+    expect(testkit.reports()[0]!.attachments).toEqual([attachment])
+  })
+
+  test('links attachments that follow the event in the envelope', () => {
+    const testkit = createTestkit()
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"event"}\n${eventPayload}\n` +
+      `{"type":"attachment","length":5,"filename":"trailing.txt"}\n` +
+      `after`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.reports()[0]!.attachments).toHaveLength(1)
+    expect(testkit.reports()[0]!.attachments[0]!.filename).toBe('trailing.txt')
+  })
+
+  test('reports without attachments expose an empty attachments array', () => {
+    const testkit = createTestkit()
+    const body = `${envelopeHeader}\n{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.reports()[0]!.attachments).toEqual([])
   })
 
   test('captures a feedback item', () => {

--- a/packages/sentry-testkit/__tests__/puppeteer.test.ts
+++ b/packages/sentry-testkit/__tests__/puppeteer.test.ts
@@ -28,6 +28,14 @@ describe('Puppeteer testkit', () => {
 {"type":"trace_metric","item_count":1,"content_type":"application/vnd.sentry.items.trace-metric+json"}
 {"items":[{"timestamp":1717081538.235,"trace_id":"abcd1234","name":"api.requests","type":"counter","value":3,"unit":"none","attributes":{"endpoint":{"value":"/api/users","type":"string"}}}]}`,
   }
+  const sentryAttachmentRequest = {
+    url: () => 'https://sentry.io/api/1234567/envelope',
+    postData: () => `{"event_id":"9f2f0e1a","sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.browser","version":"10.46.0"}}
+{"type":"attachment","length":26,"filename":"state.json","content_type":"application/json"}
+{"cart":["sku-1","sku-2"]}
+{"type":"event"}
+{"exception":{"values":[{"type":"Error","value":"checkout failed"}]},"level":"error","tags":{}}`,
+  }
   const sentrySessionRequest = {
     url: () => 'https://sentry.io/api/1234567/envelope',
     postData: () => `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.react","version":"6.11.0"}}
@@ -64,6 +72,18 @@ describe('Puppeteer testkit', () => {
     expect(metric.type).toEqual('counter')
     expect(metric.value).toEqual(3)
     expect(metric.attributes['endpoint']).toEqual('/api/users')
+  })
+
+  test('should collect attachments and link them to the report', () => {
+    testkit.puppeteer.startListening(page)
+    page.emit('request', sentryAttachmentRequest)
+    expect(testkit.attachments()).toHaveLength(1)
+    const attachment = testkit.attachments()[0]!
+    expect(attachment.filename).toEqual('state.json')
+    expect(attachment.contentType).toEqual('application/json')
+    expect(attachment.text).toEqual('{"cart":["sku-1","sku-2"]}')
+    expect(testkit.reports()).toHaveLength(1)
+    expect(testkit.reports()[0]!.attachments).toEqual([attachment])
   })
 
   test('should handle session items in an envelope request', () => {

--- a/packages/sentry-testkit/src/bytes.ts
+++ b/packages/sentry-testkit/src/bytes.ts
@@ -1,0 +1,15 @@
+// Buffer in Node.js, TextEncoder/TextDecoder in browsers (Puppeteer page context)
+export function toBytes(input: string | Uint8Array): Uint8Array {
+  if (typeof input !== 'string') {
+    return input
+  }
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(input)
+    : new TextEncoder().encode(input)
+}
+
+export function fromBytes(bytes: Uint8Array): string {
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(bytes).toString()
+    : new TextDecoder().decode(bytes)
+}

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -1,4 +1,6 @@
+import { fromBytes, toBytes } from './bytes'
 import {
+  transformAttachment,
   transformCheckIn,
   transformFeedback,
   transformLog,
@@ -6,7 +8,7 @@ import {
   transformReport,
   transformTransaction,
 } from './transformers'
-import { Testkit } from './types'
+import { Attachment, Testkit } from './types'
 
 const dsnKeys = 'source protocol user pass host port path'.split(' ')
 const dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/ //eslint-disable-line no-useless-escape
@@ -42,25 +44,11 @@ export interface EnvelopeItemHeader {
 export interface EnvelopeItem {
   header: EnvelopeItemHeader
   payload: any
+  // The undecoded payload, which attachments need to survive binary data
+  payloadBytes: Uint8Array
 }
 
 const NEWLINE = 0x0a
-
-// Buffer in Node.js, TextEncoder/TextDecoder in browsers (Puppeteer page context)
-function toBytes(input: string | Uint8Array): Uint8Array {
-  if (typeof input !== 'string') {
-    return input
-  }
-  return typeof Buffer !== 'undefined'
-    ? Buffer.from(input)
-    : new TextEncoder().encode(input)
-}
-
-function fromBytes(bytes: Uint8Array): string {
-  return typeof Buffer !== 'undefined'
-    ? Buffer.from(bytes).toString()
-    : new TextDecoder().decode(bytes)
-}
 
 // Envelope format: https://develop.sentry.dev/sdk/data-model/envelopes/
 // <envelope header>\n(<item header>\n<item payload>\n)*
@@ -93,9 +81,9 @@ export function parseEnvelope(rawBody: string | Uint8Array): EnvelopeItem[] {
     }
     const header = JSON.parse(headerLine)
 
-    let rawPayload: string
+    let payloadBytes: Uint8Array
     if (typeof header.length === 'number') {
-      rawPayload = fromBytes(bytes.subarray(next, next + header.length))
+      payloadBytes = bytes.subarray(next, next + header.length)
       offset = next + header.length
       // Skip the newline separating this payload from the next item header
       if (bytes[offset] === NEWLINE) {
@@ -103,10 +91,11 @@ export function parseEnvelope(rawBody: string | Uint8Array): EnvelopeItem[] {
       }
     } else {
       const payloadLine = readLine(next)
-      rawPayload = payloadLine.line
+      payloadBytes = bytes.subarray(next, payloadLine.next - 1)
       offset = payloadLine.next
     }
 
+    const rawPayload = fromBytes(payloadBytes)
     let payload: any
     try {
       payload = JSON.parse(rawPayload)
@@ -115,7 +104,7 @@ export function parseEnvelope(rawBody: string | Uint8Array): EnvelopeItem[] {
       payload = rawPayload
     }
 
-    items.push({ header, payload })
+    items.push({ header, payload, payloadBytes })
   }
 
   return items
@@ -125,11 +114,22 @@ export function handleEnvelopeRequestData(
   requestBody: any,
   testkit: Testkit
 ): void {
-  parseEnvelope(requestBody).forEach(({ header, payload }) => {
+  const items = parseEnvelope(requestBody)
+
+  // Attachments ride in the same envelope as the event they belong to, so they
+  // are collected up front and handed to every report from this envelope
+  const attachments: Attachment[] = items
+    .filter(({ header }) => header.type === 'attachment')
+    .map(({ header, payloadBytes }) =>
+      transformAttachment(header, payloadBytes)
+    )
+  attachments.forEach(attachment => testkit.attachments().push(attachment))
+
+  items.forEach(({ header, payload }) => {
     if (header.type === 'transaction') {
       testkit.transactions().push(transformTransaction(payload))
     } else if (header.type === 'event') {
-      testkit.reports().push(transformReport(payload))
+      testkit.reports().push(transformReport(payload, attachments))
     } else if (header.type === 'log') {
       // Log items are containers: their payload is { items: SerializedLog[] }
       const logs = (payload && payload.items) || []

--- a/packages/sentry-testkit/src/sentryTransport.ts
+++ b/packages/sentry-testkit/src/sentryTransport.ts
@@ -1,5 +1,6 @@
 import { Event } from '@sentry/types'
 import {
+  transformAttachment,
   transformCheckIn,
   transformFeedback,
   transformLog,
@@ -7,7 +8,7 @@ import {
   transformReport,
   transformTransaction,
 } from './transformers'
-import { Testkit } from './types'
+import { Attachment, Testkit } from './types'
 
 export function createSentryTransport(testkit: Testkit): any {
   return function() {
@@ -27,14 +28,21 @@ export function createSentryTransport(testkit: Testkit): any {
 
     // Send transport for API v7
     const send = function(envelope: any) {
-      const [, items] = envelope
+      const [, envelopeItems] = envelope
+      const items: [any, any][] = envelopeItems
 
-      // @ts-expect-error
+      // Attachments ride in the same envelope as the event they belong to, so
+      // they are collected up front and handed to every report from it
+      const attachments: Attachment[] = items
+        .filter(([headers]) => headers.type === 'attachment')
+        .map(([headers, data]) => transformAttachment(headers, data))
+      attachments.forEach(attachment => testkit.attachments().push(attachment))
+
       items.forEach(([headers, data]) => {
         if (headers.type === 'transaction') {
           testkit.transactions().push(transformTransaction(data))
         } else if (headers.type === 'event') {
-          testkit.reports().push(transformReport(data))
+          testkit.reports().push(transformReport(data, attachments))
         } else if (headers.type === 'log') {
           // Log items are containers: their payload is { items: SerializedLog[] }
           const logs = (data && data.items) || []

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -1,5 +1,6 @@
 import { parseEnvelope } from './parsers'
 import {
+  transformAttachment,
   transformCheckIn,
   transformFeedback,
   transformLog,
@@ -8,6 +9,7 @@ import {
   transformTransaction,
 } from './transformers'
 import {
+  Attachment,
   CheckIn,
   FeedbackReport,
   Log,
@@ -59,6 +61,7 @@ export function createTestkit(): Testkit {
   let transactions: Transaction[] = []
   let logs: Log[] = []
   let metrics: Metric[] = []
+  let attachments: Attachment[] = []
   let feedback: FeedbackReport[] = []
   let checkIns: CheckIn[] = []
 
@@ -72,11 +75,20 @@ export function createTestkit(): Testkit {
       reports.push(transformReport(JSON.parse(request.postData())))
     }
     if (/\/api\/[0-9]*\/envelope/.test(path)) {
-      parseEnvelope(request.postData()).forEach(({ header, payload }) => {
+      const items = parseEnvelope(request.postData())
+
+      const envelopeAttachments = items
+        .filter(({ header }) => header.type === 'attachment')
+        .map(({ header, payloadBytes }) =>
+          transformAttachment(header, payloadBytes)
+        )
+      envelopeAttachments.forEach(attachment => attachments.push(attachment))
+
+      items.forEach(({ header, payload }) => {
         if (header.type === 'transaction') {
           transactions.push(transformTransaction(payload))
         } else if (header.type === 'event') {
-          reports.push(transformReport(payload))
+          reports.push(transformReport(payload, envelopeAttachments))
         } else if (header.type === 'log') {
           const items = (payload && payload.items) || []
           items.forEach((log: any) => logs.push(transformLog(log)))
@@ -128,6 +140,10 @@ export function createTestkit(): Testkit {
       return metrics
     },
 
+    attachments() {
+      return attachments
+    },
+
     feedback() {
       return feedback
     },
@@ -152,6 +168,10 @@ export function createTestkit(): Testkit {
       return waitFor('metrics', () => metrics, count, options)
     },
 
+    waitForAttachments(count, options) {
+      return waitFor('attachments', () => attachments, count, options)
+    },
+
     waitForFeedback(count, options) {
       return waitFor('feedback', () => feedback, count, options)
     },
@@ -165,6 +185,7 @@ export function createTestkit(): Testkit {
       transactions = []
       logs = []
       metrics = []
+      attachments = []
       feedback = []
       checkIns = []
     },

--- a/packages/sentry-testkit/src/transformers.ts
+++ b/packages/sentry-testkit/src/transformers.ts
@@ -1,4 +1,6 @@
+import { fromBytes, toBytes } from './bytes'
 import {
+  Attachment,
   CheckIn,
   FeedbackReport,
   Log,
@@ -21,7 +23,10 @@ function unwrapAttributes(rawAttributes: any): { [key: string]: any } {
   return attributes
 }
 
-export function transformReport(report: any): Report {
+export function transformReport(
+  report: any,
+  attachments: Attachment[] = []
+): Report {
   const exception =
     report.exception && report.exception.values && report.exception.values[0]
   const error: ReportError | undefined = exception
@@ -42,7 +47,22 @@ export function transformReport(report: any): Report {
     user: report.user,
     tags: report.tags || {},
     flags: report.contexts?.flags?.values ?? [],
+    attachments,
     originalReport: report,
+  }
+}
+
+export function transformAttachment(
+  header: any,
+  data: string | Uint8Array
+): Attachment {
+  const bytes = toBytes(data)
+  return {
+    filename: header.filename,
+    contentType: header.content_type,
+    attachmentType: header.attachment_type,
+    data: bytes,
+    text: fromBytes(bytes),
   }
 }
 

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -32,6 +32,14 @@ declare namespace sentryTestkit {
     result: any
   }
 
+  interface Attachment {
+    filename: string
+    contentType?: string
+    attachmentType?: string
+    data: Uint8Array
+    text: string
+  }
+
   interface Report {
     breadcrumbs: Breadcrumb[]
     error?: ReportError
@@ -42,6 +50,7 @@ declare namespace sentryTestkit {
     user?: User
     tags: { [key: string]: string }
     flags: ReportFlag[]
+    attachments: Attachment[]
     originalReport: Event
   }
 
@@ -136,6 +145,7 @@ declare namespace sentryTestkit {
     transactions(): Transaction[]
     logs(): Log[]
     metrics(): Metric[]
+    attachments(): Attachment[]
     feedback(): FeedbackReport[]
     checkIns(): CheckIn[]
     waitForReports(count: number, options?: WaitForOptions): Promise<Report[]>
@@ -145,6 +155,10 @@ declare namespace sentryTestkit {
     ): Promise<Transaction[]>
     waitForLogs(count: number, options?: WaitForOptions): Promise<Log[]>
     waitForMetrics(count: number, options?: WaitForOptions): Promise<Metric[]>
+    waitForAttachments(
+      count: number,
+      options?: WaitForOptions
+    ): Promise<Attachment[]>
     waitForFeedback(
       count: number,
       options?: WaitForOptions


### PR DESCRIPTION
## What does this change?

Adds capture of `attachment` envelope items, exposed both as a flat `testkit.attachments()` accessor (with `waitForAttachments(count, options)`) and on the report they travelled with as `report.attachments`. Closes #307.

## Why?

Attachments were silently dropped, so a test could not assert "this error was sent together with `import.csv` containing X".

Each captured `Attachment` exposes `filename`, `contentType`, `attachmentType`, the raw bytes as `data`, and their UTF-8 decoding as `text` — `text` is what makes the common case (a JSON blob, a CSV, a log file) a one-line assertion. Attachments ride in the same envelope as their event, so each report gets the attachments from its own envelope, and an empty array when it carried none.

The envelope parser now keeps every item's undecoded bytes (`payloadBytes`), which is what lets binary attachments such as screenshots survive. The `Buffer`/`TextEncoder` helpers moved to `src/bytes.ts` so the parser and the transformers can share them without a circular import.

## Type of change

- [ ] `fix:` — bug fix (patch)
- [x] `feat:` — new feature (minor)
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change (major)
- [ ] `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` — no release impact

`Report` gains an `attachments` field and `Testkit` gains two methods — both additive, so minor.

## Checklist

**Code**
- [x] New envelope item type? All three dispatch sites updated (`parsers.ts`, `testkit.ts`, `sentryTransport.ts`)
- [x] `browser.ts` still imports nothing from Node or Express
- [x] Works on both `@sentry/*` v9 and v10

**Quality**
- [x] `yarn lint` passes
- [x] `yarn build` passes (this is the type check)
- [x] No new `@ts-ignore` or `as` casts in `src/`
- [x] Commit type above matches the actual semver impact of any `types.ts` change

The `send` transport now types the envelope items as `[any, any][]` instead of suppressing the destructuring error, so this removes one existing `@ts-expect-error` rather than adding any.

**Tests**
- [x] `yarn test` passes
- [x] Tests added or updated, driving the real Sentry SDK rather than a mock
- [x] Covers each integration mode the change affects
- [x] Verified the new test fails without the change

New `__tests__/attachments.test.ts` drives the real SDK in transport mode (capture-option and scope attachments, several attachments per error, binary payload fidelity, `report.attachments`, `waitForAttachments`, `reset`). `local-server.test.ts` posts an envelope with an attachment end-to-end, `parsers.test.ts` covers attachments before and after the event plus the undecoded-bytes behaviour, and `puppeteer.test.ts` covers the Puppeteer/Playwright path.

**Docs**
- [x] Public API change reflected in `packages/sentry-testkit-docs/docs/api/README.md`
- [x] Migration note added for breaking changes (n/a)
- [x] `CHANGELOG.md` not edited by hand

**Hygiene**
- [x] Rebased on `master` and squashed to a single conventional commit
- [x] No emojis, no AI-attribution trailers, no stray `console.log`

## Note on binary attachments

`data` holds the exact bytes wherever the testkit receives bytes: transport mode always, and the network interceptor when the body is handed over as a `Buffer`. The local server, Puppeteer and Playwright receive the request body as text, so a binary attachment arrives UTF-8 decoded there. This is documented in the API reference alongside `attachments()`.

## Relationship to #346

Rebased onto `master` now that #346 (metrics) has merged, so this is a single commit on top of `bafdd59`. The overlapping dispatch chains, `Testkit` interface, `waitFor*` lists and docs sections carry both features; the full suite (222 tests, metrics and attachments together) is green.
