### PR TITLE
feat: capture release health sessions via testkit.sessions()

### DIFF
--- a/packages/sentry-testkit-docs/docs/api/README.md
+++ b/packages/sentry-testkit-docs/docs/api/README.md
@@ -17,9 +17,11 @@ Sentry Testkit consists of a very simple and strait-forward API using the follow
 * [`attachments()`](#attachments) — captured event attachments
 * [`feedback()`](#feedback) — captured user feedback
 * [`checkIns()`](#checkins) — captured cron monitor check-ins
+* [`sessions()`](#sessions) — captured release health sessions
+* [`sessionAggregates()`](#sessionaggregates) — captured aggregated session counts
 
 **Awaiting asynchronously-sent data**
-* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForMetrics`, `waitForAttachments`, `waitForFeedback`, `waitForCheckIns`
+* [`waitForReports(count, options)`](#waitforreportscount-options) — and its siblings `waitForTransactions`, `waitForLogs`, `waitForMetrics`, `waitForAttachments`, `waitForFeedback`, `waitForCheckIns`, `waitForSessions`, `waitForSessionAggregates`
 
 **Finding and filtering**
 * [`findReport(error)`](#findreporterror)
@@ -91,7 +93,7 @@ test('waitForReports example', async function() {
 })
 ```
 
-Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)`, `waitForLogs(count, options)`, `waitForMetrics(count, options)`, `waitForAttachments(count, options)`, `waitForFeedback(count, options)` and `waitForCheckIns(count, options)`.
+Sibling helpers with the same signature exist for the other captured types: `waitForTransactions(count, options)`, `waitForLogs(count, options)`, `waitForMetrics(count, options)`, `waitForAttachments(count, options)`, `waitForFeedback(count, options)`, `waitForCheckIns(count, options)`, `waitForSessions(count, options)` and `waitForSessionAggregates(count, options)`.
 
 ### `findReport(error)`
 Finds a report by a given error.
@@ -395,6 +397,68 @@ test('check-in example', async function() {
 
     const checkIns = await testkit.waitForCheckIns(2)
     expect(checkIns.map(c => c.status)).toEqual(['in_progress', 'ok'])
+})
+```
+
+### `sessions()`
+Gets all captured [release health sessions](https://docs.sentry.io/platforms/javascript/configuration/releases/#sessions), reported either by automatic session tracking or by `Sentry.startSession()` / `Sentry.captureSession()` / `Sentry.endSession()`.
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>Session</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sid` | <code>string</code> | The session id |
+| `status` | <code>string</code> | `ok` \| `exited` \| `crashed` \| `abnormal` |
+| `errors` | <code>number</code> | The number of errors reported during the session |
+| `release` | <code>string</code> | The release, if set |
+| `environment` | <code>string</code> | The environment, if set |
+| `duration` | <code>number</code> | The session duration in seconds, for a finished session |
+| `originalSession` | <code>Object</code> | The raw session payload as sent by the SDK |
+
+For example
+```javascript
+test('session example', async function() {
+    Sentry.startSession()
+    Sentry.captureException(new Error('checkout failed'))
+    await Sentry.flush()
+    Sentry.endSession()
+
+    const sessions = await testkit.waitForSessions(1)
+    const session = sessions[sessions.length - 1]
+    expect(session.status).toEqual('exited')
+    expect(session.errors).toEqual(1)
+    expect(session.release).toEqual('my-release')
+})
+```
+
+:::note
+The Node SDK starts a session when `Sentry.init()` runs, and `Sentry.startSession()` ends that one before starting a new one. Assert on the session you started rather than assuming a single captured session — either take the last one, or match on the `sid` from `Sentry.getIsolationScope().getSession()`.
+:::
+
+### `sessionAggregates()`
+Gets all captured aggregated session counts. Server-side SDKs report request-mode release health in `sessions` envelopes, which batch per-minute counts instead of individual sessions. Each time bucket in such an envelope becomes one entry.
+
+**Returns**: <code>Array</code> - where each member of the array consists of a <code>SessionAggregate</code> type:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `started` | <code>string</code> | The ISO timestamp of the time bucket |
+| `exited` | <code>number</code> | The number of sessions that exited without errors |
+| `errored` | <code>number</code> | The number of sessions that had errors |
+| `crashed` | <code>number</code> | The number of crashed sessions |
+| `abnormal` | <code>number</code> | The number of abnormally-ended sessions |
+| `release` | <code>string</code> | The release, if set |
+| `environment` | <code>string</code> | The environment, if set |
+| `originalAggregate` | <code>Object</code> | The raw aggregate payload as sent by the SDK |
+
+For example
+```javascript
+test('aggregated sessions example', async function() {
+    // your server framework reports these while handling requests
+    const aggregates = await testkit.waitForSessionAggregates(1)
+
+    expect(aggregates[0].crashed).toEqual(0)
+    expect(aggregates[0].exited).toEqual(2)
 })
 ```
 

--- a/packages/sentry-testkit-docs/docs/getting-started.md
+++ b/packages/sentry-testkit-docs/docs/getting-started.md
@@ -44,7 +44,7 @@ test('collect performance events', function () {
 });
 ```
 
-### Beyond errors: logs, metrics, attachments, feedback and check-ins
+### Beyond errors: logs, metrics, attachments, feedback, check-ins and sessions
 
 `sentry-testkit` captures more than errors and transactions. If your app uses these Sentry features, you can assert on them the same way — each has its own accessor and an awaitable `waitFor*` helper:
 
@@ -53,6 +53,7 @@ test('collect performance events', function () {
 - **[Attachments](/docs/api#attachments)** — files sent with an event via `scope.addAttachment(...)` or the `attachments` capture option, via `testkit.attachments()` and `report.attachments`
 - **[User feedback](/docs/api#feedback)** — submissions from `Sentry.captureFeedback(...)` or the feedback widget, via `testkit.feedback()`
 - **[Cron check-ins](/docs/api#checkins)** — monitor check-ins from `Sentry.captureCheckIn(...)` / `Sentry.withMonitor(...)`, via `testkit.checkIns()`
+- **[Release health sessions](/docs/api#sessions)** — sessions from automatic session tracking or `Sentry.startSession()` / `Sentry.endSession()`, via `testkit.sessions()` and `testkit.sessionAggregates()`
 
 ```javascript
 Sentry.captureFeedback({ message: 'the checkout page is confusing' })

--- a/packages/sentry-testkit/__tests__/parsers.test.ts
+++ b/packages/sentry-testkit/__tests__/parsers.test.ts
@@ -4,7 +4,7 @@ import { createTestkit } from '../src/testkit'
 const envelopeHeader = `{"sent_at":"2021-08-17T14:27:12.489Z","sdk":{"name":"sentry.javascript.node","version":"6.11.0"}}`
 const eventPayload = `{"exception":{"values":[{"type":"Error","value":"testing error"}]},"level":"error","tags":{}}`
 const transactionPayload = `{"type":"transaction","transaction":"test-transaction","contexts":{"trace":{"trace_id":"1234","span_id":"5678"}},"spans":[]}`
-const sessionPayload = `{"sid":"abc","init":false,"started":"2021-08-17T14:27:11.361Z","status":"ok","errors":1}`
+const sessionPayload = `{"sid":"abc","init":false,"started":"2021-08-17T14:27:11.361Z","status":"ok","errors":1,"duration":4.5,"attrs":{"release":"1.0.0","environment":"production"}}`
 
 describe('parseEnvelope', () => {
   test('parses a single-item event envelope', () => {
@@ -298,9 +298,56 @@ describe('handleEnvelopeRequestData', () => {
     expect(testkit.checkIns()[0]!.duration).toBe(3.2)
   })
 
+  test('captures a session item alongside the event of the same envelope', () => {
+    const testkit = createTestkit()
+    const body =
+      `${envelopeHeader}\n` +
+      `{"type":"session"}\n${sessionPayload}\n` +
+      `{"type":"event"}\n${eventPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.sessions()).toHaveLength(1)
+    const session = testkit.sessions()[0]!
+    expect(session.sid).toBe('abc')
+    expect(session.status).toBe('ok')
+    expect(session.errors).toBe(1)
+    expect(session.duration).toBe(4.5)
+    expect(session.release).toBe('1.0.0')
+    expect(session.environment).toBe('production')
+    expect(testkit.reports()).toHaveLength(1)
+  })
+
+  test('captures aggregates from a sessions container item', () => {
+    const testkit = createTestkit()
+    const aggregatesPayload = JSON.stringify({
+      attrs: { release: '1.0.0', environment: 'production' },
+      aggregates: [
+        { started: '2021-08-17T14:27:00.000Z', exited: 2, crashed: 1 },
+        { started: '2021-08-17T14:28:00.000Z', errored: 3, abnormal: 1 },
+      ],
+    })
+    const body = `${envelopeHeader}\n{"type":"sessions"}\n${aggregatesPayload}`
+
+    handleEnvelopeRequestData(body, testkit)
+
+    expect(testkit.sessionAggregates()).toHaveLength(2)
+    const aggregate = testkit.sessionAggregates()[0]!
+    expect(aggregate.started).toBe('2021-08-17T14:27:00.000Z')
+    expect(aggregate.exited).toBe(2)
+    expect(aggregate.crashed).toBe(1)
+    expect(aggregate.errored).toBe(0)
+    expect(aggregate.abnormal).toBe(0)
+    expect(aggregate.release).toBe('1.0.0')
+    expect(aggregate.environment).toBe('production')
+    expect(testkit.sessionAggregates()[1]!.errored).toBe(3)
+    expect(testkit.sessionAggregates()[1]!.abnormal).toBe(1)
+    expect(testkit.sessions()).toHaveLength(0)
+  })
+
   test('ignores unknown item types without throwing', () => {
     const testkit = createTestkit()
-    const body = `${envelopeHeader}\n{"type":"session"}\n${sessionPayload}`
+    const body = `${envelopeHeader}\n{"type":"client_report"}\n{"timestamp":123,"discarded_events":[]}`
 
     expect(() => handleEnvelopeRequestData(body, testkit)).not.toThrow()
     expect(testkit.reports()).toHaveLength(0)

--- a/packages/sentry-testkit/__tests__/sessions.test.ts
+++ b/packages/sentry-testkit/__tests__/sessions.test.ts
@@ -1,0 +1,105 @@
+import * as Sentry from '@sentry/node'
+import sentryTestkit from '../src/index'
+
+const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+describe('sentry test-kit test suite - sessions / release health', function() {
+  beforeAll(() =>
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      environment: 'ci',
+      transport: sentryTransport,
+    })
+  )
+
+  // The Node SDK starts a session at init, and startSession() ends it. Closing
+  // it up front keeps each test's assertions about its own session.
+  beforeEach(() => {
+    Sentry.endSession()
+    testkit.reset()
+  })
+
+  const startSession = () => {
+    Sentry.startSession()
+    return Sentry.getIsolationScope().getSession()!.sid
+  }
+
+  test('sessions() is empty when nothing was reported', () => {
+    expect(testkit.sessions()).toEqual([])
+  })
+
+  test('captures a started session with its release and environment', async () => {
+    const sid = startSession()
+    Sentry.captureSession()
+    const [session] = await testkit.waitForSessions(1)
+
+    expect(session!.sid).toBe(sid)
+    expect(session!.status).toBe('ok')
+    expect(session!.errors).toBe(0)
+    expect(session!.release).toBe('test')
+    expect(session!.environment).toBe('ci')
+  })
+
+  test('captures an exited session with its duration', async () => {
+    const sid = startSession()
+    Sentry.endSession()
+    const [session] = await testkit.waitForSessions(1)
+
+    expect(session!.sid).toBe(sid)
+    expect(session!.status).toBe('exited')
+    expect(session!.duration).toEqual(expect.any(Number))
+  })
+
+  test('counts errors reported during a session', async () => {
+    startSession()
+    Sentry.captureException(new Error('session error'))
+    await Sentry.flush()
+    Sentry.endSession()
+    const sessions = await testkit.waitForSessions(1)
+
+    expect(sessions[sessions.length - 1]!.errors).toBe(1)
+  })
+
+  test('exposes the raw session payload as originalSession', async () => {
+    startSession()
+    Sentry.captureSession()
+    const [session] = await testkit.waitForSessions(1)
+
+    expect(session!.originalSession.sid).toBe(session!.sid)
+    expect(session!.originalSession.attrs.release).toBe('test')
+  })
+
+  test('captures aggregated sessions sent by server-side release health', async () => {
+    Sentry.getClient()!.sendSession({
+      attrs: { release: 'test', environment: 'ci' },
+      aggregates: [
+        { started: '2024-01-01T00:00:00.000Z', exited: 2, crashed: 1 },
+        { started: '2024-01-01T00:01:00.000Z', errored: 3 },
+      ],
+    })
+    const aggregates = await testkit.waitForSessionAggregates(2)
+
+    expect(aggregates[0]!.started).toBe('2024-01-01T00:00:00.000Z')
+    expect(aggregates[0]!.exited).toBe(2)
+    expect(aggregates[0]!.crashed).toBe(1)
+    expect(aggregates[0]!.errored).toBe(0)
+    expect(aggregates[0]!.abnormal).toBe(0)
+    expect(aggregates[0]!.release).toBe('test')
+    expect(aggregates[0]!.environment).toBe('ci')
+    expect(aggregates[1]!.errored).toBe(3)
+    expect(testkit.sessions()).toHaveLength(0)
+  })
+
+  test('reset() clears captured sessions', async () => {
+    startSession()
+    Sentry.captureSession()
+    await testkit.waitForSessions(1)
+
+    testkit.reset()
+
+    expect(testkit.sessions()).toHaveLength(0)
+    expect(testkit.sessionAggregates()).toHaveLength(0)
+  })
+})

--- a/packages/sentry-testkit/src/parsers.ts
+++ b/packages/sentry-testkit/src/parsers.ts
@@ -6,6 +6,8 @@ import {
   transformLog,
   transformMetric,
   transformReport,
+  transformSession,
+  transformSessionAggregate,
   transformTransaction,
 } from './transformers'
 import { Attachment, Testkit } from './types'
@@ -144,6 +146,16 @@ export function handleEnvelopeRequestData(
       testkit.feedback().push(transformFeedback(payload))
     } else if (header.type === 'check_in') {
       testkit.checkIns().push(transformCheckIn(payload))
+    } else if (header.type === 'session') {
+      testkit.sessions().push(transformSession(payload))
+    } else if (header.type === 'sessions') {
+      // Aggregate session items batch per-time-bucket counts under `aggregates`
+      const aggregates = (payload && payload.aggregates) || []
+      aggregates.forEach((aggregate: any) =>
+        testkit
+          .sessionAggregates()
+          .push(transformSessionAggregate(aggregate, payload.attrs))
+      )
     }
   })
 }

--- a/packages/sentry-testkit/src/sentryTransport.ts
+++ b/packages/sentry-testkit/src/sentryTransport.ts
@@ -6,6 +6,8 @@ import {
   transformLog,
   transformMetric,
   transformReport,
+  transformSession,
+  transformSessionAggregate,
   transformTransaction,
 } from './transformers'
 import { Attachment, Testkit } from './types'
@@ -57,6 +59,16 @@ export function createSentryTransport(testkit: Testkit): any {
           testkit.feedback().push(transformFeedback(data))
         } else if (headers.type === 'check_in') {
           testkit.checkIns().push(transformCheckIn(data))
+        } else if (headers.type === 'session') {
+          testkit.sessions().push(transformSession(data))
+        } else if (headers.type === 'sessions') {
+          // Aggregate session items batch per-time-bucket counts under `aggregates`
+          const aggregates = (data && data.aggregates) || []
+          aggregates.forEach((aggregate: any) =>
+            testkit
+              .sessionAggregates()
+              .push(transformSessionAggregate(aggregate, data.attrs))
+          )
         }
       })
 

--- a/packages/sentry-testkit/src/testkit.ts
+++ b/packages/sentry-testkit/src/testkit.ts
@@ -6,6 +6,8 @@ import {
   transformLog,
   transformMetric,
   transformReport,
+  transformSession,
+  transformSessionAggregate,
   transformTransaction,
 } from './transformers'
 import {
@@ -16,6 +18,8 @@ import {
   Metric,
   Report,
   ReportError,
+  Session,
+  SessionAggregate,
   Testkit,
   Transaction,
 } from './types'
@@ -64,6 +68,8 @@ export function createTestkit(): Testkit {
   let attachments: Attachment[] = []
   let feedback: FeedbackReport[] = []
   let checkIns: CheckIn[] = []
+  let sessions: Session[] = []
+  let sessionAggregates: SessionAggregate[] = []
 
   const createRequestHandler = (baseUrl: string) => (request: any) => {
     const url = request.url()
@@ -99,6 +105,15 @@ export function createTestkit(): Testkit {
           feedback.push(transformFeedback(payload))
         } else if (header.type === 'check_in') {
           checkIns.push(transformCheckIn(payload))
+        } else if (header.type === 'session') {
+          sessions.push(transformSession(payload))
+        } else if (header.type === 'sessions') {
+          const aggregates = (payload && payload.aggregates) || []
+          aggregates.forEach((aggregate: any) =>
+            sessionAggregates.push(
+              transformSessionAggregate(aggregate, payload.attrs)
+            )
+          )
         }
       })
     }
@@ -152,6 +167,14 @@ export function createTestkit(): Testkit {
       return checkIns
     },
 
+    sessions() {
+      return sessions
+    },
+
+    sessionAggregates() {
+      return sessionAggregates
+    },
+
     waitForReports(count, options) {
       return waitFor('reports', () => reports, count, options)
     },
@@ -180,6 +203,19 @@ export function createTestkit(): Testkit {
       return waitFor('check-ins', () => checkIns, count, options)
     },
 
+    waitForSessions(count, options) {
+      return waitFor('sessions', () => sessions, count, options)
+    },
+
+    waitForSessionAggregates(count, options) {
+      return waitFor(
+        'session aggregates',
+        () => sessionAggregates,
+        count,
+        options
+      )
+    },
+
     reset() {
       reports = []
       transactions = []
@@ -188,6 +224,8 @@ export function createTestkit(): Testkit {
       attachments = []
       feedback = []
       checkIns = []
+      sessions = []
+      sessionAggregates = []
     },
 
     getExceptionAt(index: number) {

--- a/packages/sentry-testkit/src/transformers.ts
+++ b/packages/sentry-testkit/src/transformers.ts
@@ -7,6 +7,8 @@ import {
   Metric,
   Report,
   ReportError,
+  Session,
+  SessionAggregate,
   Transaction,
 } from './types'
 
@@ -116,6 +118,35 @@ export function transformCheckIn(checkIn: any): CheckIn {
     release: checkIn.release,
     environment: checkIn.environment,
     originalCheckIn: checkIn,
+  }
+}
+
+export function transformSession(session: any): Session {
+  return {
+    sid: session.sid,
+    status: session.status,
+    errors: session.errors ?? 0,
+    // Release health attributes are nested under `attrs` on the wire
+    release: session.attrs?.release,
+    environment: session.attrs?.environment,
+    duration: session.duration,
+    originalSession: session,
+  }
+}
+
+export function transformSessionAggregate(
+  aggregate: any,
+  attrs: any
+): SessionAggregate {
+  return {
+    started: aggregate.started,
+    exited: aggregate.exited ?? 0,
+    errored: aggregate.errored ?? 0,
+    crashed: aggregate.crashed ?? 0,
+    abnormal: aggregate.abnormal ?? 0,
+    release: attrs?.release,
+    environment: attrs?.environment,
+    originalAggregate: aggregate,
   }
 }
 

--- a/packages/sentry-testkit/src/types.ts
+++ b/packages/sentry-testkit/src/types.ts
@@ -128,6 +128,29 @@ declare namespace sentryTestkit {
     originalCheckIn: any
   }
 
+  type SessionStatus = 'ok' | 'exited' | 'crashed' | 'abnormal'
+
+  interface Session {
+    sid: string
+    status: SessionStatus
+    errors: number
+    release?: string
+    environment?: string
+    duration?: number
+    originalSession: any
+  }
+
+  interface SessionAggregate {
+    started: string
+    exited: number
+    errored: number
+    crashed: number
+    abnormal: number
+    release?: string
+    environment?: string
+    originalAggregate: any
+  }
+
   interface WaitForOptions {
     timeout?: number
   }
@@ -148,6 +171,8 @@ declare namespace sentryTestkit {
     attachments(): Attachment[]
     feedback(): FeedbackReport[]
     checkIns(): CheckIn[]
+    sessions(): Session[]
+    sessionAggregates(): SessionAggregate[]
     waitForReports(count: number, options?: WaitForOptions): Promise<Report[]>
     waitForTransactions(
       count: number,
@@ -164,6 +189,11 @@ declare namespace sentryTestkit {
       options?: WaitForOptions
     ): Promise<FeedbackReport[]>
     waitForCheckIns(count: number, options?: WaitForOptions): Promise<CheckIn[]>
+    waitForSessions(count: number, options?: WaitForOptions): Promise<Session[]>
+    waitForSessionAggregates(
+      count: number,
+      options?: WaitForOptions
+    ): Promise<SessionAggregate[]>
     reset(): void
     getExceptionAt(index: number): ReportError | undefined
     findReport(e: Error): Report | undefined


### PR DESCRIPTION
## What does this change?

Captures Sentry release health sessions. Adds `testkit.sessions()` and `testkit.sessionAggregates()`, each with a `waitFor*` sibling, and clears both in `reset()`.

Closes #303

## Why?

`session` envelope items were silently dropped, so users could not assert that a crashed or errored session was reported for their release.

The issue proposed `testkit.sessions()` and mentioned aggregate `sessions` items only as an implementation note. Those items carry per-time-bucket counts (`exited`, `errored`, `crashed`, `abnormal`) with no `sid` or `status`, so they cannot honestly fold into `Session[]` and get their own accessor instead.

Worth knowing for anyone using this: the Node SDK starts a session at `init()`, and `Sentry.startSession()` ends that one before starting a new one — so a naive `waitForSessions(1)` resolves with the *previous* session. This is documented in a note under `sessions()`, and the tests close the ambient session in `beforeEach` and match on `sid`.

## Type of change

- [ ] `fix:` — bug fix (patch)
- [x] `feat:` — new feature (minor)
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change (major)
- [ ] `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` — no release impact

## Checklist

**[Code](https://github.com/zivl/sentry-testkit/blob/master/skills/code-writing.md)**
- [x] New envelope item type? All three dispatch sites updated (`parsers.ts`, `testkit.ts`, `sentryTransport.ts`)
- [x] `browser.ts` still imports nothing from Node or Express
- [x] Works on both `@sentry/*` v9 and v10 — verified `startSession`, `endSession`, `getIsolationScope().getSession()`, `client.sendSession` and the `attrs` nesting all exist in v9

**[Quality](https://github.com/zivl/sentry-testkit/blob/master/skills/code-quality.md)**
- [x] `yarn lint` passes
- [x] `yarn build` passes (this is the type check)
- [x] No new `@ts-ignore` or `as` casts in `src/`
- [x] Commit type above matches the actual semver impact of any `types.ts` change

**[Tests](https://github.com/zivl/sentry-testkit/blob/master/skills/testing.md)**
- [x] `yarn test` passes
- [x] Tests added or updated, driving the real Sentry SDK rather than a mock
- [x] Covers each integration mode the change affects — transport mode in `sessions.test.ts`, the network-capture path via `handleEnvelopeRequestData` in `parsers.test.ts`
- [x] Verified the new test fails without the change

**[Docs](https://github.com/zivl/sentry-testkit/blob/master/skills/docs-writing.md)**
- [x] Public API change reflected in `packages/sentry-testkit-docs/docs/api/README.md`
- [x] Migration note added for breaking changes — n/a, additive only
- [x] `CHANGELOG.md` not edited by hand

**Hygiene**
- [x] Rebased on `master` and squashed to a single conventional commit
- [x] No emojis, no AI-attribution trailers, no stray `console.log`

## Note on an unrelated flake

On one full-suite run, `feedback.test.ts > does not record feedback as a report` failed with a stray `Error: boom` report leaking from an earlier test in the same file — that test's `captureException` can land after the next test's `reset()`. It did not reproduce in 5 subsequent full-suite runs or 5 isolated runs, with or without this change. Pre-existing and unrelated to sessions, but it will flake in CI eventually and deserves its own fix.
